### PR TITLE
Markdown support for multiple types of Header, italics, Bold, images, links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # VS Code Configuration
 .vscode
+
+#Windows 11
+Scripts/
+.cfg

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Silkie
 > Static site generator with the smoothness of silk
 
-Silkie is a simple and smooth static site generator. It can parse text files (".txt" files) and 
+Silkie is a simple and smooth static site generator. It can parse text files (".txt" or ".md" files) and 
 generate HTML files from them.
 
 Check out the [demo](https://oliver-pham.github.io/silkie/dist/The%20Adventure%20of%20the%20Speckled%20Band) generated from this [text file](https://raw.githubusercontent.com/Seneca-CDOT/topics-in-open-source-2021/main/release-1/Sherlock-Holmes-Selected-Stories/The%20Adventure%20of%20the%20Speckled%20Band.txt) (with help from [new.css](https://newcss.net/)).
@@ -51,6 +51,9 @@ Options:
 2. Run the program
     ```
     python silkie.py -h
+
+    Other examples:
+      python silkie.py -i examples/md/markdowntest1.md 
     ```
 
 ## Contributing

--- a/blueprintmd/markdowntest1.html
+++ b/blueprintmd/markdowntest1.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title></title>
+  </head>
+  <body>
+<h1>h1 Heading 😎</h1>
+<h2>h2 Heading</h2>
+<h3>h3 Heading</h3>
+<h2>Typographic replacements</h2>
+<p>Enable typographer option to see result.
+© © ® ® ™ ™ § § ±
+“Smartypants, double quotes” and ‘single quotes’</p>
+<h2>Emphasis</h2>
+<p><strong>This is bold text</strong></p>
+<p><strong>This is bold text</strong></p>
+<p><em>This is italic text</em></p>
+<p><em>This is italic text</em></p>
+<p><s>Strikethrough</s></p>
+<ul>
+<li>Create a list by starting a line with <code>+</code>, <code>-</code>, or <code>*</code></li>
+<li>Sub-lists are made by indenting 2 spaces:
+<ul>
+<li>Marker character change forces new list start:
+<ul>
+<li>Ac tristique libero volutpat at</li>
+</ul>
+<ul>
+<li>Facilisis in pretium nisl aliquet</li>
+</ul>
+<ul>
+<li>Nulla volutpat aliquam velit</li>
+</ul>
+</li>
+</ul>
+</li>
+<li>Very easy!</li>
+</ul>
+<p>Block code “fences”</p>
+<pre class="hljs"><code>Sample text here...
+</code></pre>
+<h2>Tables</h2>
+<table>
+<thead>
+<tr>
+<th>Option</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>data</td>
+<td>path to data files to supply the data that will be passed into templates.</td>
+</tr>
+<tr>
+<td>engine</td>
+<td>engine to be used for processing templates. Handlebars is the default.</td>
+</tr>
+<tr>
+<td>ext</td>
+<td>extension to be used for dest files.</td>
+</tr>
+</tbody>
+</table>
+<h2>Links</h2>
+<p><a href="http://dev.nodeca.com">link text</a></p>
+<p><a href="http://nodeca.github.io/pica/demo/" title="title text!">link with title</a></p>
+<p>Autoconverted link <a href="https://github.com/nodeca/pica">https://github.com/nodeca/pica</a> (enable linkify to see)</p>
+<h2>Images</h2>
+<p><img src="https://octodex.github.com/images/minion.png" alt="Minion">
+<img src="https://octodex.github.com/images/stormtroopocat.jpg" alt="Stormtroopocat" title="The Stormtroopocat"></p>
+<p>Like links, Images also have a footnote style syntax</p>
+<p><img src="https://octodex.github.com/images/dojocat.jpg" alt="Alt text" title="The Dojocat"></p>
+<p>With a reference later in the document defining the URL location:</p>
+<p>Credits: <a href="https://markdown-it.github.io/">https://markdown-it.github.io/</a></p>
+  </body>
+  </html>

--- a/blueprintmd/new.css
+++ b/blueprintmd/new.css
@@ -1,0 +1,432 @@
+:root {
+	--nc-font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+	--nc-font-mono: Consolas, monaco, 'Ubuntu Mono', 'Liberation Mono', 'Courier New', Courier, monospace;
+	--nc-tx-1: #000000;
+	--nc-tx-2: #1A1A1A;
+	--nc-bg-1: #FFFFFF;
+	--nc-bg-2: #F6F8FA;
+	--nc-bg-3: #E5E7EB;
+	--nc-lk-1: #0070F3;
+	--nc-lk-2: #0366D6;
+	--nc-lk-tx: #FFFFFF;
+	--nc-ac-1: #79FFE1;
+    --nc-ac-tx: #0C4047;
+}
+
+@media (prefers-color-scheme: dark) {
+	:root {
+		--nc-tx-1: #ffffff;
+		--nc-tx-2: #eeeeee;
+		--nc-bg-1: #000000;
+		--nc-bg-2: #111111;
+		--nc-bg-3: #222222;
+		--nc-lk-1: #3291FF;
+		--nc-lk-2: #0070F3;
+		--nc-lk-tx: #FFFFFF;
+		--nc-ac-1: #7928CA;
+		--nc-ac-tx: #FFFFFF;
+	}
+}
+
+* {
+	/* Reset margins and padding */
+	margin: 0;
+	padding: 0;
+}
+
+address,
+area,
+article,
+aside,
+audio,
+blockquote,
+datalist,
+details,
+dl,
+fieldset,
+figure,
+form,
+input,
+iframe,
+img,
+meter,
+nav,
+ol,
+optgroup,
+option,
+output,
+p,
+pre,
+progress,
+ruby,
+section,
+table,
+textarea,
+ul,
+video {
+	/* Margins for most elements */
+	margin-bottom: 1rem;
+}
+
+html,input,select,button {
+	/* Set body font family and some finicky elements */
+	font-family: var(--nc-font-sans);
+}
+
+body {
+	/* Center body in page */
+	margin: 0 auto;
+	max-width: 750px;
+	padding: 2rem;
+	border-radius: 6px;
+	overflow-x: hidden;
+	word-break: break-word;
+	overflow-wrap: break-word;
+	background: var(--nc-bg-1);
+
+	/* Main body text */
+	color: var(--nc-tx-2);
+	font-size: 1.03rem;
+	line-height: 1.5;
+}
+
+::selection {
+	/* Set background color for selected text */
+	background: var(--nc-ac-1);
+	color: var(--nc-ac-tx);
+}
+
+h1,h2,h3,h4,h5,h6 {
+	line-height: 1;
+	color: var(--nc-tx-1);
+	padding-top: .875rem;
+}
+
+h1,
+h2,
+h3 {
+	color: var(--nc-tx-1);
+	padding-bottom: 2px;
+	margin-bottom: 8px;
+	border-bottom: 1px solid var(--nc-bg-2);
+}
+
+h4,
+h5,
+h6 {
+	margin-bottom: .3rem;
+}
+
+h1 {
+	font-size: 2.25rem;
+}
+
+h2 {
+	font-size: 1.85rem;
+}
+
+h3 {
+	font-size: 1.55rem;
+}
+
+h4 {
+	font-size: 1.25rem;
+}
+
+h5 {
+	font-size: 1rem;
+}
+
+h6 {
+	font-size: .875rem;
+}
+
+a {
+	color: var(--nc-lk-1);
+}
+
+a:hover {
+	color: var(--nc-lk-2);
+}
+
+abbr:hover {
+	/* Set the '?' cursor while hovering an abbreviation */
+	cursor: help;
+}
+
+blockquote {
+	padding: 1.5rem;
+	background: var(--nc-bg-2);
+	border-left: 5px solid var(--nc-bg-3);
+}
+
+abbr {
+	cursor: help;
+}
+
+blockquote *:last-child {
+	padding-bottom: 0;
+	margin-bottom: 0;
+}
+
+header {
+	background: var(--nc-bg-2);
+	border-bottom: 1px solid var(--nc-bg-3);
+	padding: 2rem 1.5rem;
+	
+	/* This sets the right and left margins to cancel out the body's margins. It's width is still the same, but the background stretches across the page's width. */
+
+	margin: -2rem calc(0px - (50vw - 50%)) 2rem;
+
+	/* Shorthand for:
+
+	margin-top: -2rem;
+	margin-bottom: 2rem;
+
+	margin-left: calc(0px - (50vw - 50%));
+	margin-right: calc(0px - (50vw - 50%)); */
+	
+	padding-left: calc(50vw - 50%);
+	padding-right: calc(50vw - 50%);
+}
+
+header h1,
+header h2,
+header h3 {
+	padding-bottom: 0;
+	border-bottom: 0;
+}
+
+header > *:first-child {
+	margin-top: 0;
+	padding-top: 0;
+}
+
+header > *:last-child {
+	margin-bottom: 0;
+}
+
+a button,
+button,
+input[type="submit"],
+input[type="reset"],
+input[type="button"] {
+	font-size: 1rem;
+	display: inline-block;
+	padding: 6px 12px;
+	text-align: center;
+	text-decoration: none;
+	white-space: nowrap;
+	background: var(--nc-lk-1);
+	color: var(--nc-lk-tx);
+	border: 0;
+	border-radius: 4px;
+	box-sizing: border-box;
+	cursor: pointer;
+	color: var(--nc-lk-tx);
+}
+
+a button[disabled],
+button[disabled],
+input[type="submit"][disabled],
+input[type="reset"][disabled],
+input[type="button"][disabled] {
+	cursor: default;
+	opacity: .5;
+
+	/* Set the [X] cursor while hovering a disabled link */
+	cursor: not-allowed;
+}
+
+.button:focus,
+.button:hover,
+button:focus,
+button:hover,
+input[type="submit"]:focus,
+input[type="submit"]:hover,
+input[type="reset"]:focus,
+input[type="reset"]:hover,
+input[type="button"]:focus,
+input[type="button"]:hover {
+	background: var(--nc-lk-2);
+}
+
+code,
+pre,
+kbd,
+samp {
+	/* Set the font family for monospaced elements */
+	font-family: var(--nc-font-mono);
+}
+
+code,
+samp,
+kbd,
+pre {
+	/* The main preformatted style. This is changed slightly across different cases. */
+	background: var(--nc-bg-2);
+	border: 1px solid var(--nc-bg-3);
+	border-radius: 4px;
+	padding: 3px 6px;
+	font-size: 0.9rem;
+}
+
+kbd {
+	/* Makes the kbd element look like a keyboard key */
+	border-bottom: 3px solid var(--nc-bg-3);
+}
+
+pre {
+	padding: 1rem 1.4rem;
+	max-width: 100%;
+	overflow: auto;
+}
+
+pre code {
+	/* When <code> is in a <pre>, reset it's formatting to blend in */
+	background: inherit;
+	font-size: inherit;
+	color: inherit;
+	border: 0;
+	padding: 0;
+	margin: 0;
+}
+
+code pre {
+	/* When <pre> is in a <code>, reset it's formatting to blend in */
+	display: inline;
+	background: inherit;
+	font-size: inherit;
+	color: inherit;
+	border: 0;
+	padding: 0;
+	margin: 0;
+}
+
+details {
+	/* Make the <details> look more "clickable" */
+	padding: .6rem 1rem;
+	background: var(--nc-bg-2);
+	border: 1px solid var(--nc-bg-3);
+	border-radius: 4px;
+}
+
+summary {
+	/* Makes the <summary> look more like a "clickable" link with the pointer cursor */
+	cursor: pointer;
+	font-weight: bold;
+}
+
+details[open] {
+	/* Adjust the <details> padding while open */
+	padding-bottom: .75rem;
+}
+
+details[open] summary {
+	/* Adjust the <details> padding while open */
+	margin-bottom: 6px;
+}
+
+details[open]>*:last-child {
+	/* Resets the bottom margin of the last element in the <details> while <details> is opened. This prevents double margins/paddings. */
+	margin-bottom: 0;
+}
+
+dt {
+	font-weight: bold;
+}
+
+dd::before {
+	/* Add an arrow to data table definitions */
+	content: '→ ';
+}
+
+hr {
+	/* Reset the border of the <hr> separator, then set a better line */
+	border: 0;
+	border-bottom: 1px solid var(--nc-bg-3);
+	margin: 1rem auto;
+}
+
+fieldset {
+	margin-top: 1rem;
+	padding: 2rem;
+	border: 1px solid var(--nc-bg-3);
+	border-radius: 4px;
+}
+
+legend {
+	padding: auto .5rem;
+}
+
+table {
+	/* border-collapse sets the table's elements to share borders, rather than floating as separate "boxes". */
+	border-collapse: collapse;
+	width: 100%
+}
+
+td,
+th {
+	border: 1px solid var(--nc-bg-3);
+	text-align: left;
+	padding: .5rem;
+}
+
+th {
+	background: var(--nc-bg-2);
+}
+
+tr:nth-child(even) {
+	/* Set every other cell slightly darker. Improves readability. */
+	background: var(--nc-bg-2);
+}
+
+table caption {
+	font-weight: bold;
+	margin-bottom: .5rem;
+}
+
+textarea {
+	/* Don't let the <textarea> extend off the screen naturally or when dragged by the user */
+	max-width: 100%;
+}
+
+ol,
+ul {
+	/* Replace the browser default padding */
+	padding-left: 2rem;
+}
+
+li {
+	margin-top: .4rem;
+}
+
+ul ul,
+ol ul,
+ul ol,
+ol ol {
+	margin-bottom: 0;
+}
+
+mark {
+	padding: 3px 6px;
+	background: var(--nc-ac-1);
+	color: var(--nc-ac-tx);
+}
+
+textarea,
+select,
+input {
+	padding: 6px 12px;
+	margin-bottom: .5rem;
+	background: var(--nc-bg-2);
+	color: var(--nc-tx-2);
+	border: 1px solid var(--nc-bg-3);
+	border-radius: 4px;
+	box-shadow: none;
+	box-sizing: border-box;
+}
+
+img {
+	max-width: 100%;
+}

--- a/examples/The Naval Treaty.txt
+++ b/examples/The Naval Treaty.txt
@@ -1,0 +1,1628 @@
+The Naval Treaty
+
+
+The July which immediately succeeded my marriage was made
+memorable by three cases of interest, in which I had the
+privilege of being associated with Sherlock Holmes and of
+studying his methods. I find them recorded in my notes under the
+headings of “The Adventure of the Second Stain,” “The Adventure
+of the Naval Treaty,” and “The Adventure of the Tired Captain.”
+The first of these, however, deals with interest of such
+importance and implicates so many of the first families in the
+kingdom that for many years it will be impossible to make it
+public. No case, however, in which Holmes was engaged has ever
+illustrated the value of his analytical methods so clearly or has
+impressed those who were associated with him so deeply. I still
+retain an almost verbatim report of the interview in which he
+demonstrated the true facts of the case to Monsieur Dubuque of
+the Paris police, and Fritz von Waldbaum, the well-known
+specialist of Dantzig, both of whom had wasted their energies
+upon what proved to be side-issues. The new century will have
+come, however, before the story can be safely told. Meanwhile I
+pass on to the second on my list, which promised also at one time
+to be of national importance, and was marked by several incidents
+which give it a quite unique character.
+
+During my school-days I had been intimately associated with a lad
+named Percy Phelps, who was of much the same age as myself,
+though he was two classes ahead of me. He was a very brilliant
+boy, and carried away every prize which the school had to offer,
+finished his exploits by winning a scholarship which sent him on
+to continue his triumphant career at Cambridge. He was, I
+remember, extremely well connected, and even when we were all
+little boys together we knew that his mother’s brother was Lord
+Holdhurst, the great conservative politician. This gaudy
+relationship did him little good at school. On the contrary, it
+seemed rather a piquant thing to us to chevy him about the
+playground and hit him over the shins with a wicket. But it was
+another thing when he came out into the world. I heard vaguely
+that his abilities and the influences which he commanded had won
+him a good position at the Foreign Office, and then he passed
+completely out of my mind until the following letter recalled his
+existence:
+
+Briarbrae, Woking.
+    My dear Watson,—I have no doubt that you can remember
+    “Tadpole” Phelps, who was in the fifth form when you were in
+    the third. It is possible even that you may have heard that
+    through my uncle’s influence I obtained a good appointment at
+    the Foreign Office, and that I was in a situation of trust
+    and honour until a horrible misfortune came suddenly to blast
+    my career.
+    There is no use writing of the details of that dreadful
+    event. In the event of your acceding to my request it is
+    probable that I shall have to narrate them to you. I have
+    only just recovered from nine weeks of brain-fever, and am
+    still exceedingly weak. Do you think that you could bring
+    your friend Mr. Holmes down to see me? I should like to have
+    his opinion of the case, though the authorities assure me
+    that nothing more can be done. Do try to bring him down, and
+    as soon as possible. Every minute seems an hour while I live
+    in this state of horrible suspense. Assure him that if I have
+    not asked his advice sooner it was not because I did not
+    appreciate his talents, but because I have been off my head
+    ever since the blow fell. Now I am clear again, though I dare
+    not think of it too much for fear of a relapse. I am still so
+    weak that I have to write, as you see, by dictating. Do try
+    to bring him.
+
+Your old schoolfellow,
+Percy Phelps.
+
+There was something that touched me as I read this letter,
+something pitiable in the reiterated appeals to bring Holmes. So
+moved was I that even had it been a difficult matter I should
+have tried it, but of course I knew well that Holmes loved his
+art, so that he was ever as ready to bring his aid as his client
+could be to receive it. My wife agreed with me that not a moment
+should be lost in laying the matter before him, and so within an
+hour of breakfast-time I found myself back once more in the old
+rooms in Baker Street.
+
+Holmes was seated at his side-table clad in his dressing-gown,
+and working hard over a chemical investigation. A large curved
+retort was boiling furiously in the bluish flame of a Bunsen
+burner, and the distilled drops were condensing into a two-litre
+measure. My friend hardly glanced up as I entered, and I, seeing
+that his investigation must be of importance, seated myself in an
+armchair and waited. He dipped into this bottle or that, drawing
+out a few drops of each with his glass pipette, and finally
+brought a test-tube containing a solution over to the table. In
+his right hand he held a slip of litmus-paper.
+
+“You come at a crisis, Watson,” said he. “If this paper remains
+blue, all is well. If it turns red, it means a man’s life.” He
+dipped it into the test-tube and it flushed at once into a dull,
+dirty crimson. “Hum! I thought as much!” he cried. “I will be at
+your service in an instant, Watson. You will find tobacco in the
+Persian slipper.” He turned to his desk and scribbled off several
+telegrams, which were handed over to the page-boy. Then he threw
+himself down into the chair opposite, and drew up his knees until
+his fingers clasped round his long, thin shins.
+
+“A very commonplace little murder,” said he. “You’ve got
+something better, I fancy. You are the stormy petrel of crime,
+Watson. What is it?”
+
+I handed him the letter, which he read with the most concentrated
+attention.
+
+“It does not tell us very much, does it?” he remarked, as he
+handed it back to me.
+
+“Hardly anything.”
+
+“And yet the writing is of interest.”
+
+“But the writing is not his own.”
+
+“Precisely. It is a woman’s.”
+
+“A man’s surely,” I cried.
+
+“No, a woman’s, and a woman of rare character. You see, at the
+commencement of an investigation it is something to know that
+your client is in close contact with some one who, for good or
+evil, has an exceptional nature. My interest is already awakened
+in the case. If you are ready we will start at once for Woking,
+and see this diplomatist who is in such evil case, and the lady
+to whom he dictates his letters.”
+
+We were fortunate enough to catch an early train at Waterloo, and
+in a little under an hour we found ourselves among the fir-woods
+and the heather of Woking. Briarbrae proved to be a large
+detached house standing in extensive grounds within a few
+minutes’ walk of the station. On sending in our cards we were
+shown into an elegantly appointed drawing-room, where we were
+joined in a few minutes by a rather stout man who received us
+with much hospitality. His age may have been nearer forty than
+thirty, but his cheeks were so ruddy and his eyes so merry that
+he still conveyed the impression of a plump and mischievous boy.
+
+“I am so glad that you have come,” said he, shaking our hands
+with effusion. “Percy has been inquiring for you all morning. Ah,
+poor old chap, he clings to any straw! His father and his mother
+asked me to see you, for the mere mention of the subject is very
+painful to them.”
+
+“We have had no details yet,” observed Holmes. “I perceive that
+you are not yourself a member of the family.”
+
+Our acquaintance looked surprised, and then, glancing down, he
+began to laugh.
+
+“Of course you saw the ‘J.H.’ monogram on my locket,” said he.
+“For a moment I thought you had done something clever. Joseph
+Harrison is my name, and as Percy is to marry my sister Annie I
+shall at least be a relation by marriage. You will find my sister
+in his room, for she has nursed him hand-and-foot this two months
+back. Perhaps we’d better go in at once, for I know how impatient
+he is.”
+
+The chamber in which we were shown was on the same floor as the
+drawing-room. It was furnished partly as a sitting and partly as
+a bedroom, with flowers arranged daintily in every nook and
+corner. A young man, very pale and worn, was lying upon a sofa
+near the open window, through which came the rich scent of the
+garden and the balmy summer air. A woman was sitting beside him,
+who rose as we entered.
+
+“Shall I leave, Percy?” she asked.
+
+He clutched her hand to detain her. “How are you, Watson?” said
+he, cordially. “I should never have known you under that
+moustache, and I daresay you would not be prepared to swear to
+me. This I presume is your celebrated friend, Mr. Sherlock
+Holmes?”
+
+I introduced him in a few words, and we both sat down. The stout
+young man had left us, but his sister still remained with her
+hand in that of the invalid. She was a striking-looking woman, a
+little short and thick for symmetry, but with a beautiful olive
+complexion, large, dark, Italian eyes, and a wealth of deep black
+hair. Her rich tints made the white face of her companion the
+more worn and haggard by the contrast.
+
+“I won’t waste your time,” said he, raising himself upon the
+sofa. “I’ll plunge into the matter without further preamble. I
+was a happy and successful man, Mr. Holmes, and on the eve of
+being married, when a sudden and dreadful misfortune wrecked all
+my prospects in life.
+
+“I was, as Watson may have told you, in the Foreign Office, and
+through the influences of my uncle, Lord Holdhurst, I rose
+rapidly to a responsible position. When my uncle became foreign
+minister in this administration he gave me several missions of
+trust, and as I always brought them to a successful conclusion,
+he came at last to have the utmost confidence in my ability and
+tact.
+
+“Nearly ten weeks ago—to be more accurate, on the 23rd of May—he
+called me into his private room, and, after complimenting me on
+the good work which I had done, he informed me that he had a new
+commission of trust for me to execute.
+
+“‘This,’ said he, taking a grey roll of paper from his bureau,
+‘is the original of that secret treaty between England and Italy
+of which, I regret to say, some rumours have already got into the
+public press. It is of enormous importance that nothing further
+should leak out. The French or the Russian embassy would pay an
+immense sum to learn the contents of these papers. They should
+not leave my bureau were it not that it is absolutely necessary
+to have them copied. You have a desk in your office?’
+
+“‘Yes, sir.’
+
+“‘Then take the treaty and lock it up there. I shall give
+directions that you may remain behind when the others go, so that
+you may copy it at your leisure without fear of being overlooked.
+When you have finished, relock both the original and the draft in
+the desk, and hand them over to me personally to-morrow morning.’
+
+“I took the papers and—”
+
+“Excuse me an instant,” said Holmes. “Were you alone during this
+conversation?”
+
+“Absolutely.”
+
+“In a large room?”
+
+“Thirty feet each way.”
+
+“In the centre?”
+
+“Yes, about it.”
+
+“And speaking low?”
+
+“My uncle’s voice is always remarkably low. I hardly spoke at
+all.”
+
+“Thank you,” said Holmes, shutting his eyes; “pray go on.”
+
+“I did exactly what he indicated, and waited until the other
+clerks had departed. One of them in my room, Charles Gorot, had
+some arrears of work to make up, so I left him there and went out
+to dine. When I returned he was gone. I was anxious to hurry my
+work, for I knew that Joseph—the Mr. Harrison whom you saw just
+now—was in town, and that he would travel down to Woking by the
+eleven o’clock train, and I wanted if possible to catch it.
+
+“When I came to examine the treaty I saw at once that it was of
+such importance that my uncle had been guilty of no exaggeration
+in what he had said. Without going into details, I may say that
+it defined the position of Great Britain towards the Triple
+Alliance, and fore-shadowed the policy which this country would
+pursue in the event of the French fleet gaining a complete
+ascendancy over that of Italy in the Mediterranean. The questions
+treated in it were purely naval. At the end were the signatures
+of the high dignitaries who had signed it. I glanced my eyes over
+it, and then settled down to my task of copying.
+
+“It was a long document, written in the French language, and
+containing twenty-six separate articles. I copied as quickly as I
+could, but at nine o’clock I had only done nine articles, and it
+seemed hopeless for me to attempt to catch my train. I was
+feeling drowsy and stupid, partly from my dinner and also from
+the effects of a long day’s work. A cup of coffee would clear my
+brain. A commissionnaire remains all night in a little lodge at
+the foot of the stairs, and is in the habit of making coffee at
+his spirit-lamp for any of the officials who may be working over
+time. I rang the bell, therefore, to summon him.
+
+“To my surprise, it was a woman who answered the summons, a
+large, coarse-faced, elderly woman, in an apron. She explained
+that she was the commissionnaire’s wife, who did the charing, and
+I gave her the order for the coffee.
+
+“I wrote two more articles and then, feeling more drowsy than
+ever, I rose and walked up and down the room to stretch my legs.
+My coffee had not yet come, and I wondered what the cause of the
+delay could be. Opening the door, I started down the corridor to
+find out. There was a straight passage, dimly lighted, which led
+from the room in which I had been working, and was the only exit
+from it. It ended in a curving staircase, with the
+commissionnaire’s lodge in the passage at the bottom. Half-way
+down this staircase is a small landing, with another passage
+running into it at right angles. This second one leads by means
+of a second small stair to a side door, used by servants, and
+also as a short cut by clerks when coming from Charles Street.
+Here is a rough chart of the place.”
+
+rough chart
+
+“Thank you. I think that I quite follow you,” said Sherlock
+Holmes.
+
+“It is of the utmost importance that you should notice this
+point. I went down the stairs and into the hall, where I found
+the commissionnaire fast asleep in his box, with the kettle
+boiling furiously upon the spirit-lamp. I took off the kettle and
+blew out the lamp, for the water was spurting over the floor.
+Then I put out my hand and was about to shake the man, who was
+still sleeping soundly, when a bell over his head rang loudly,
+and he woke with a start.
+
+“‘Mr. Phelps, sir!’ said he, looking at me in bewilderment.
+
+“‘I came down to see if my coffee was ready.’
+
+“‘I was boiling the kettle when I fell asleep, sir.’ He looked at
+me and then up at the still quivering bell with an ever-growing
+astonishment upon his face.
+
+“‘If you was here, sir, then who rang the bell?’ he asked.
+
+“‘The bell!’ I cried. ‘What bell is it?’
+
+“‘It’s the bell of the room you were working in.’
+
+“A cold hand seemed to close round my heart. Some one, then, was
+in that room where my precious treaty lay upon the table. I ran
+frantically up the stairs and along the passage. There was no one
+in the corridors, Mr. Holmes. There was no one in the room. All
+was exactly as I left it, save only that the papers which had
+been committed to my care had been taken from the desk on which
+they lay. The copy was there, and the original was gone.”
+
+Holmes sat up in his chair and rubbed his hands. I could see that
+the problem was entirely to his heart. “Pray, what did you do
+then?” he murmured.
+
+“I recognised in an instant that the thief must have come up the
+stairs from the side door. Of course I must have met him if he
+had come the other way.”
+
+“You were satisfied that he could not have been concealed in the
+room all the time, or in the corridor which you have just
+described as dimly lighted?”
+
+“It is absolutely impossible. A rat could not conceal himself
+either in the room or the corridor. There is no cover at all.”
+
+“Thank you. Pray proceed.”
+
+“The commissionnaire, seeing by my pale face that something was
+to be feared, had followed me upstairs. Now we both rushed along
+the corridor and down the steep steps which led to Charles
+Street. The door at the bottom was closed, but unlocked. We flung
+it open and rushed out. I can distinctly remember that as we did
+so there came three chimes from a neighbouring clock. It was
+quarter to ten.”
+
+“That is of enormous importance,” said Holmes, making a note upon
+his shirt-cuff.
+
+“The night was very dark, and a thin, warm rain was falling.
+There was no one in Charles Street, but a great traffic was going
+on, as usual, in Whitehall, at the extremity. We rushed along the
+pavement, bare-headed as we were, and at the far corner we found
+a policeman standing.
+
+“‘A robbery has been committed,’ I gasped. ‘A document of immense
+value has been stolen from the Foreign Office. Has any one passed
+this way?’
+
+“‘I have been standing here for a quarter of an hour, sir,’ said
+he; ‘only one person has passed during that time—a woman, tall
+and elderly, with a Paisley shawl.’
+
+“‘Ah, that is only my wife,’ cried the commissionnaire; ‘has no
+one else passed?’
+
+“‘No one.’
+
+“‘Then it must be the other way that the thief took,’ cried the
+fellow, tugging at my sleeve.
+
+“‘But I was not satisfied, and the attempts which he made to draw
+me away increased my suspicions.
+
+“‘Which way did the woman go?’ I cried.
+
+“‘I don’t know, sir. I noticed her pass, but I had no special
+reason for watching her. She seemed to be in a hurry.’
+
+“‘How long ago was it?’
+
+“‘Oh, not very many minutes.’
+
+“‘Within the last five?’
+
+“‘Well, it could not be more than five.’
+
+“‘You’re only wasting your time, sir, and every minute now is of
+importance,’ cried the commissionnaire; ‘take my word for it that
+my old woman has nothing to do with it, and come down to the
+other end of the street. Well, if you won’t, I will.’ And with
+that he rushed off in the other direction.
+
+“But I was after him in an instant and caught him by the sleeve.
+
+“‘Where do you live?’ said I.
+
+“‘16 Ivy Lane, Brixton,’ he answered. ‘But don’t let yourself be
+drawn away upon a false scent, Mr. Phelps. Come to the other end
+of the street and let us see if we can hear of anything.’
+
+“Nothing was to be lost by following his advice. With the
+policeman we both hurried down, but only to find the street full
+of traffic, many people coming and going, but all only too eager
+to get to a place of safety upon so wet a night. There was no
+lounger who could tell us who had passed.
+
+“Then we returned to the office, and searched the stairs and the
+passage without result. The corridor which led to the room was
+laid down with a kind of creamy linoleum which shows an
+impression very easily. We examined it very carefully, but found
+no outline of any footmark.”
+
+“Had it been raining all evening?”
+
+“Since about seven.”
+
+“How is it, then, that the woman who came into the room about
+nine left no traces with her muddy boots?”
+
+“I am glad you raised the point. It occurred to me at the time.
+The charwomen are in the habit of taking off their boots at the
+commissionnaire’s office, and putting on list slippers.”
+
+“That is very clear. There were no marks, then, though the night
+was a wet one? The chain of events is certainly one of
+extraordinary interest. What did you do next?
+
+“We examined the room also. There is no possibility of a secret
+door, and the windows are quite thirty feet from the ground. Both
+of them were fastened on the inside. The carpet prevents any
+possibility of a trap-door, and the ceiling is of the ordinary
+whitewashed kind. I will pledge my life that whoever stole my
+papers could only have come through the door.”
+
+“How about the fireplace?”
+
+“They use none. There is a stove. The bell-rope hangs from the
+wire just to the right of my desk. Whoever rang it must have come
+right up to the desk to do it. But why should any criminal wish
+to ring the bell? It is a most insoluble mystery.”
+
+“Certainly the incident was unusual. What were your next steps?
+You examined the room, I presume, to see if the intruder had left
+any traces—any cigar-end or dropped glove or hairpin or other
+trifle?”
+
+“There was nothing of the sort.”
+
+“No smell?”
+
+“Well, we never thought of that.”
+
+“Ah, a scent of tobacco would have been worth a great deal to us
+in such an investigation.”
+
+“I never smoke myself, so I think I should have observed it if
+there had been any smell of tobacco. There was absolutely no clue
+of any kind. The only tangible fact was that the
+commissionnaire’s wife—Mrs. Tangey was the name—had hurried out
+of the place. He could give no explanation save that it was about
+the time when the woman always went home. The policeman and I
+agreed that our best plan would be to seize the woman before she
+could get rid of the papers, presuming that she had them.
+
+“The alarm had reached Scotland Yard by this time, and Mr.
+Forbes, the detective, came round at once and took up the case
+with a great deal of energy. We hired a hansom, and in half an
+hour we were at the address which had been given to us. A young
+woman opened the door, who proved to be Mrs. Tangey’s eldest
+daughter. Her mother had not come back yet, and we were shown
+into the front room to wait.
+
+“About ten minutes later a knock came at the door, and here we
+made the one serious mistake for which I blame myself. Instead of
+opening the door ourselves, we allowed the girl to do so. We
+heard her say, ‘Mother, there are two men in the house waiting to
+see you,’ and an instant afterwards we heard the patter of feet
+rushing down the passage. Forbes flung open the door, and we both
+ran into the back room or kitchen, but the woman had got there
+before us. She stared at us with defiant eyes, and then, suddenly
+recognising me, an expression of absolute astonishment came over
+her face.
+
+“‘Why, if it isn’t Mr. Phelps, of the office!’ she cried.
+
+“‘Come, come, who did you think we were when you ran away from
+us?’ asked my companion.
+
+“‘I thought you were the brokers,’ said she, ‘we have had some
+trouble with a tradesman.’
+
+“‘That’s not quite good enough,’ answered Forbes. ‘We have reason
+to believe that you have taken a paper of importance from the
+Foreign Office, and that you ran in here to dispose of it. You
+must come back with us to Scotland Yard to be searched.’
+
+“It was in vain that she protested and resisted. A four-wheeler
+was brought, and we all three drove back in it. We had first made
+an examination of the kitchen, and especially of the kitchen
+fire, to see whether she might have made away with the papers
+during the instant that she was alone. There were no signs,
+however, of any ashes or scraps. When we reached Scotland Yard
+she was handed over at once to the female searcher. I waited in
+an agony of suspense until she came back with her report. There
+were no signs of the papers.
+
+“Then for the first time the horror of my situation came in its
+full force. Hitherto I had been acting, and action had numbed
+thought. I had been so confident of regaining the treaty at once
+that I had not dared to think of what would be the consequence if
+I failed to do so. But now there was nothing more to be done, and
+I had leisure to realize my position. It was horrible. Watson
+there would tell you that I was a nervous, sensitive boy at
+school. It is my nature. I thought of my uncle and of his
+colleagues in the Cabinet, of the shame which I had brought upon
+him, upon myself, upon every one connected with me. What though I
+was the victim of an extraordinary accident? No allowance is made
+for accidents where diplomatic interests are at stake. I was
+ruined, shamefully, hopelessly ruined. I don’t know what I did. I
+fancy I must have made a scene. I have a dim recollection of a
+group of officials who crowded round me, endeavouring to soothe
+me. One of them drove down with me to Waterloo, and saw me into
+the Woking train. I believe that he would have come all the way
+had it not been that Dr. Ferrier, who lives near me, was going
+down by that very train. The doctor most kindly took charge of
+me, and it was well he did so, for I had a fit in the station,
+and before we reached home I was practically a raving maniac.
+
+“You can imagine the state of things here when they were roused
+from their beds by the doctor’s ringing and found me in this
+condition. Poor Annie here and my mother were broken-hearted. Dr.
+Ferrier had just heard enough from the detective at the station
+to be able to give an idea of what had happened, and his story
+did not mend matters. It was evident to all that I was in for a
+long illness, so Joseph was bundled out of this cheery bedroom,
+and it was turned into a sick-room for me. Here I have lain, Mr.
+Holmes, for over nine weeks, unconscious, and raving with
+brain-fever. If it had not been for Miss Harrison here and for
+the doctor’s care I should not be speaking to you now. She has
+nursed me by day and a hired nurse has looked after me by night,
+for in my mad fits I was capable of anything. Slowly my reason
+has cleared, but it is only during the last three days that my
+memory has quite returned. Sometimes I wish that it never had.
+The first thing that I did was to wire to Mr. Forbes, who had the
+case in hand. He came out, and assures me that, though everything
+has been done, no trace of a clue has been discovered. The
+commissionnaire and his wife have been examined in every way
+without any light being thrown upon the matter. The suspicions of
+the police then rested upon young Gorot, who, as you may
+remember, stayed over time in the office that night. His
+remaining behind and his French name were really the only two
+points which could suggest suspicion; but, as a matter of fact, I
+did not begin work until he had gone, and his people are of
+Huguenot extraction, but as English in sympathy and tradition as
+you and I are. Nothing was found to implicate him in any way, and
+there the matter dropped. I turn to you, Mr. Holmes, as
+absolutely my last hope. If you fail me, then my honour as well
+as my position are forever forfeited.”
+
+The invalid sank back upon his cushions, tired out by this long
+recital, while his nurse poured him out a glass of some
+stimulating medicine. Holmes sat silently, with his head thrown
+back and his eyes closed, in an attitude which might seem
+listless to a stranger, but which I knew betokened the most
+intense self-absorption.
+
+“You statement has been so explicit,” said he at last, “that you
+have really left me very few questions to ask. There is one of
+the very utmost importance, however. Did you tell any one that
+you had this special task to perform?”
+
+“No one.”
+
+“Not Miss Harrison here, for example?”
+
+“No. I had not been back to Woking between getting the order and
+executing the commission.”
+
+“And none of your people had by chance been to see you?”
+
+“None.”
+
+“Did any of them know their way about in the office?”
+
+“Oh, yes, all of them had been shown over it.”
+
+“Still, of course, if you said nothing to any one about the
+treaty these inquiries are irrelevant.”
+
+“I said nothing.”
+
+“Do you know anything of the commissionnaire?”
+
+“Nothing except that he is an old soldier.”
+
+“What regiment?”
+
+“Oh, I have heard—Coldstream Guards.”
+
+“Thank you. I have no doubt I can get details from Forbes. The
+authorities are excellent at amassing facts, though they do not
+always use them to advantage. What a lovely thing a rose is!”
+
+He walked past the couch to the open window, and held up the
+drooping stalk of a moss-rose, looking down at the dainty blend
+of crimson and green. It was a new phase of his character to me,
+for I had never before seen him show any keen interest in natural
+objects.
+
+“There is nothing in which deduction is so necessary as in
+religion,” said he, leaning with his back against the shutters.
+“It can be built up as an exact science by the reasoner. Our
+highest assurance of the goodness of Providence seems to me to
+rest in the flowers. All other things, our powers our desires,
+our food, are all really necessary for our existence in the first
+instance. But this rose is an extra. Its smell and its colour are
+an embellishment of life, not a condition of it. It is only
+goodness which gives extras, and so I say again that we have much
+to hope from the flowers.”
+
+Percy Phelps and his nurse looked at Holmes during this
+demonstration with surprise and a good deal of disappointment
+written upon their faces. He had fallen into a reverie, with the
+moss-rose between his fingers. It had lasted some minutes before
+the young lady broke in upon it.
+
+“Do you see any prospect of solving this mystery, Mr. Holmes?”
+she asked, with a touch of asperity in her voice.
+
+“Oh, the mystery!” he answered, coming back with a start to the
+realities of life. “Well, it would be absurd to deny that the
+case is a very abstruse and complicated one, but I can promise
+you that I will look into the matter and let you know any points
+which may strike me.”
+
+“Do you see any clue?”
+
+“You have furnished me with seven, but, of course, I must test
+them before I can pronounce upon their value.”
+
+“You suspect some one?”
+
+“I suspect myself.”
+
+“What!”
+
+“Of coming to conclusions too rapidly.”
+
+“Then go to London and test your conclusions.”
+
+“Your advice is very excellent, Miss Harrison,” said Holmes,
+rising. “I think, Watson, we cannot do better. Do not allow
+yourself to indulge in false hopes, Mr. Phelps. The affair is a
+very tangled one.”
+
+“I shall be in a fever until I see you again,” cried the
+diplomatist.
+
+“Well, I’ll come out by the same train to-morrow, though it’s
+more than likely that my report will be a negative one.”
+
+“God bless you for promising to come,” cried our client. “It
+gives me fresh life to know that something is being done. By the
+way, I have had a letter from Lord Holdhurst.”
+
+“Ha! What did he say?”
+
+“He was cold, but not harsh. I daresay my severe illness
+prevented him from being that. He repeated that the matter was of
+the utmost importance, and added that no steps would be taken
+about my future—by which he means, of course, my dismissal—until
+my health was restored and I had an opportunity of repairing my
+misfortune.”
+
+“Well, that was reasonable and considerate,” said Holmes. “Come,
+Watson, for we have a good day’s work before us in town.”
+
+Mr. Joseph Harrison drove us down to the station, and we were
+soon whirling up in a Portsmouth train. Holmes was sunk in
+profound thought, and hardly opened his mouth until we had passed
+Clapham Junction.
+
+“It’s a very cheery thing to come into London by any of these
+lines which run high, and allow you to look down upon the houses
+like this.”
+
+I thought he was joking, for the view was sordid enough, but he
+soon explained himself.
+
+“Look at those big, isolated clumps of building rising up above
+the slates, like brick islands in a lead-coloured sea.”
+
+“The board-schools.”
+
+“Light-houses, my boy! Beacons of the future! Capsules with
+hundreds of bright little seeds in each, out of which will spring
+the wise, better England of the future. I suppose that man Phelps
+does not drink?”
+
+“I should not think so.”
+
+“Nor should I, but we are bound to take every possibility into
+account. The poor devil has certainly got himself into very deep
+water, and it’s a question whether we shall ever be able to get
+him ashore. What did you think of Miss Harrison?”
+
+“A girl of strong character.”
+
+“Yes, but she is a good sort, or I am mistaken. She and her
+brother are the only children of an iron-master somewhere up
+Northumberland way. He got engaged to her when traveling last
+winter, and she came down to be introduced to his people, with
+her brother as escort. Then came the smash, and she stayed on to
+nurse her lover, while brother Joseph, finding himself pretty
+snug, stayed on too. I’ve been making a few independent
+inquiries, you see. But to-day must be a day of inquiries.”
+
+“My practice—” I began.
+
+“Oh, if you find your own cases more interesting than mine—” said
+Holmes, with some asperity.
+
+“I was going to say that my practice could get along very well
+for a day or two, since it is the slackest time in the year.”
+
+“Excellent,” said he, recovering his good-humour. “Then we’ll
+look into this matter together. I think that we should begin by
+seeing Forbes. He can probably tell us all the details we want
+until we know from what side the case is to be approached.”
+
+“You said you had a clue?”
+
+“Well, we have several, but we can only test their value by
+further inquiry. The most difficult crime to track is the one
+which is purposeless. Now this is not purposeless. Who is it who
+profits by it? There is the French ambassador, there is the
+Russian, there is whoever might sell it to either of these, and
+there is Lord Holdhurst.”
+
+“Lord Holdhurst!”
+
+“Well, it is just conceivable that a statesman might find himself
+in a position where he was not sorry to have such a document
+accidentally destroyed.”
+
+“Not a statesman with the honourable record of Lord Holdhurst?”
+
+“It is a possibility and we cannot afford to disregard it. We
+shall see the noble lord to-day and find out if he can tell us
+anything. Meanwhile I have already set inquiries on foot.”
+
+“Already?”
+
+“Yes, I sent wires from Woking station to every evening paper in
+London. This advertisement will appear in each of them.”
+
+He handed over a sheet torn from a note-book. On it was scribbled
+in pencil:
+
+“£10 Reward.—The number of the cab which dropped a fare at or
+about the door of the Foreign Office in Charles Street at quarter
+to ten in the evening of May 23rd. Apply 221B, Baker Street.”
+
+“You are confident that the thief came in a cab?”
+
+“If not, there is no harm done. But if Mr. Phelps is correct in
+stating that there is no hiding-place either in the room or the
+corridors, then the person must have come from outside. If he
+came from outside on so wet a night, and yet left no trace of
+damp upon the linoleum, which was examined within a few minutes
+of his passing, then it is exceeding probable that he came in a
+cab. Yes, I think that we may safely deduce a cab.”
+
+“It sounds plausible.”
+
+“That is one of the clues of which I spoke. It may lead us to
+something. And then, of course, there is the bell—which is the
+most distinctive feature of the case. Why should the bell ring?
+Was it the thief who did it out of bravado? Or was it some one
+who was with the thief who did it in order to prevent the crime?
+Or was it an accident? Or was it—?” He sank back into the state
+of intense and silent thought from which he had emerged; but it
+seemed to me, accustomed as I was to his every mood, that some
+new possibility had dawned suddenly upon him.
+
+It was twenty past three when we reached our terminus, and after
+a hasty luncheon at the buffet we pushed on at once to Scotland
+Yard. Holmes had already wired to Forbes, and we found him
+waiting to receive us—a small, foxy man with a sharp but by no
+means amiable expression. He was decidedly frigid in his manner
+to us, especially when he heard the errand upon which we had
+come.
+
+“I’ve heard of your methods before now, Mr. Holmes,” said he,
+tartly. “You are ready enough to use all the information that the
+police can lay at your disposal, and then you try to finish the
+case yourself and bring discredit on them.”
+
+“On the contrary,” said Holmes, “out of my last fifty-three cases
+my name has only appeared in four, and the police have had all
+the credit in forty-nine. I don’t blame you for not knowing this,
+for you are young and inexperienced, but if you wish to get on in
+your new duties you will work with me and not against me.”
+
+“I’d be very glad of a hint or two,” said the detective, changing
+his manner. “I’ve certainly had no credit from the case so far.”
+
+“What steps have you taken?”
+
+“Tangey, the commissionnaire, has been shadowed. He left the
+Guards with a good character and we can find nothing against him.
+His wife is a bad lot, though. I fancy she knows more about this
+than appears.”
+
+“Have you shadowed her?”
+
+“We have set one of our women on to her. Mrs. Tangey drinks, and
+our woman has been with her twice when she was well on, but she
+could get nothing out of her.”
+
+“I understand that they have had brokers in the house?”
+
+“Yes, but they were paid off.”
+
+“Where did the money come from?”
+
+“That was all right. His pension was due. They have not shown any
+sign of being in funds.”
+
+“What explanation did she give of having answered the bell when
+Mr. Phelps rang for the coffee?”
+
+“She said that her husband was very tired and she wished to
+relieve him.”
+
+“Well, certainly that would agree with his being found a little
+later asleep in his chair. There is nothing against them then but
+the woman’s character. Did you ask her why she hurried away that
+night? Her haste attracted the attention of the police
+constable.”
+
+“She was later than usual and wanted to get home.”
+
+“Did you point out to her that you and Mr. Phelps, who started at
+least twenty minutes after her, got home before her?”
+
+“She explains that by the difference between a ‘bus and a
+hansom.”
+
+“Did she make it clear why, on reaching her house, she ran into
+the back kitchen?”
+
+“Because she had the money there with which to pay off the
+brokers.”
+
+“She has at least an answer for everything. Did you ask her
+whether in leaving she met any one or saw any one loitering about
+Charles Street?”
+
+“She saw no one but the constable.”
+
+“Well, you seem to have cross-examined her pretty thoroughly.
+What else have you done?”
+
+“The clerk Gorot has been shadowed all these nine weeks, but
+without result. We can show nothing against him.”
+
+“Anything else?”
+
+“Well, we have nothing else to go upon—no evidence of any kind.”
+
+“Have you formed a theory about how that bell rang?”
+
+“Well, I must confess that it beats me. It was a cool hand,
+whoever it was, to go and give the alarm like that.”
+
+“Yes, it was a queer thing to do. Many thanks to you for what you
+have told me. If I can put the man into your hands you shall hear
+from me. Come along, Watson.”
+
+“Where are we going to now?” I asked, as we left the office.
+
+“We are now going to interview Lord Holdhurst, the cabinet
+minister and future premier of England.”
+
+We were fortunate in finding that Lord Holdhurst was still in his
+chambers in Downing Street, and on Holmes sending in his card we
+were instantly shown up. The statesman received us with that
+old-fashioned courtesy for which he is remarkable, and seated us
+on the two luxuriant lounges on either side of the fireplace.
+Standing on the rug between us, with his slight, tall figure, his
+sharp features, thoughtful face, and curling hair prematurely
+tinged with grey, he seemed to represent that not too common
+type, a nobleman who is in truth noble.
+
+“Your name is very familiar to me, Mr. Holmes,” said he, smiling.
+“And, of course, I cannot pretend to be ignorant of the object of
+your visit. There has only been one occurrence in these offices
+which could call for your attention. In whose interest are you
+acting, may I ask?”
+
+“In that of Mr. Percy Phelps,” answered Holmes.
+
+“Ah, my unfortunate nephew! You can understand that our kinship
+makes it the more impossible for me to screen him in any way. I
+fear that the incident must have a very prejudicial effect upon
+his career.”
+
+“But if the document is found?”
+
+“Ah, that, of course, would be different.”
+
+“I had one or two questions which I wished to ask you, Lord
+Holdhurst.”
+
+“I shall be happy to give you any information in my power.”
+
+“Was it in this room that you gave your instructions as to the
+copying of the document?”
+
+“It was.”
+
+“Then you could hardly have been overheard?”
+
+“It is out of the question.”
+
+“Did you ever mention to any one that it was your intention to
+give any one the treaty to be copied?”
+
+“Never.”
+
+“You are certain of that?”
+
+“Absolutely.”
+
+“Well, since you never said so, and Mr. Phelps never said so, and
+nobody else knew anything of the matter, then the thief’s
+presence in the room was purely accidental. He saw his chance and
+he took it.”
+
+The statesman smiled. “You take me out of my province there,”
+said he.
+
+Holmes considered for a moment. “There is another very important
+point which I wish to discuss with you,” said he. “You feared, as
+I understand, that very grave results might follow from the
+details of this treaty becoming known.”
+
+A shadow passed over the expressive face of the statesman. “Very
+grave results indeed.”
+
+“And have they occurred?”
+
+“Not yet.”
+
+“If the treaty had reached, let us say, the French or Russian
+Foreign Office, you would expect to hear of it?”
+
+“I should,” said Lord Holdhurst, with a wry face.
+
+“Since nearly ten weeks have elapsed, then, and nothing has been
+heard, it is not unfair to suppose that for some reason the
+treaty has not reached them.”
+
+Lord Holdhurst shrugged his shoulders.
+
+“We can hardly suppose, Mr. Holmes, that the thief took the
+treaty in order to frame it and hang it up.”
+
+“Perhaps he is waiting for a better price.”
+
+“If he waits a little longer he will get no price at all. The
+treaty will cease to be secret in a few months.”
+
+“That is most important,” said Holmes. “Of course, it is a
+possible supposition that the thief has had a sudden illness—”
+
+“An attack of brain-fever, for example?” asked the statesman,
+flashing a swift glance at him.
+
+“I did not say so,” said Holmes, imperturbably. “And now, Lord
+Holdhurst, we have already taken up too much of your valuable
+time, and we shall wish you good-day.”
+
+“Every success to your investigation, be the criminal who it
+may,” answered the nobleman, as he bowed us out the door.
+
+“He’s a fine fellow,” said Holmes, as we came out into Whitehall.
+“But he has a struggle to keep up his position. He is far from
+rich and has many calls. You noticed, of course, that his boots
+had been resoled. Now, Watson, I won’t detain you from your
+legitimate work any longer. I shall do nothing more to-day,
+unless I have an answer to my cab advertisement. But I should be
+extremely obliged to you if you would come down with me to Woking
+to-morrow, by the same train which we took yesterday.”
+
+I met him accordingly next morning and we travelled down to
+Woking together. He had had no answer to his advertisement, he
+said, and no fresh light had been thrown upon the case. He had,
+when he so willed it, the utter immobility of countenance of a
+red Indian, and I could not gather from his appearance whether he
+was satisfied or not with the position of the case. His
+conversation, I remember, was about the Bertillon system of
+measurements, and he expressed his enthusiastic admiration of the
+French savant.
+
+We found our client still under the charge of his devoted nurse,
+but looking considerably better than before. He rose from the
+sofa and greeted us without difficulty when we entered.
+
+“Any news?” he asked, eagerly.
+
+“My report, as I expected, is a negative one,” said Holmes. “I
+have seen Forbes, and I have seen your uncle, and I have set one
+or two trains of inquiry upon foot which may lead to something.”
+
+“You have not lost heart, then?”
+
+“By no means.”
+
+“God bless you for saying that!” cried Miss Harrison. “If we keep
+our courage and our patience the truth must come out.”
+
+“We have more to tell you than you have for us,” said Phelps,
+reseating himself upon the couch.
+
+“I hoped you might have something.”
+
+“Yes, we have had an adventure during the night, and one which
+might have proved to be a serious one.” His expression grew very
+grave as he spoke, and a look of something akin to fear sprang up
+in his eyes. “Do you know,” said he, “that I begin to believe
+that I am the unconscious centre of some monstrous conspiracy,
+and that my life is aimed at as well as my honour?”
+
+“Ah!” cried Holmes.
+
+“It sounds incredible, for I have not, as far as I know, an enemy
+in the world. Yet from last night’s experience I can come to no
+other conclusion.”
+
+“Pray let me hear it.”
+
+“You must know that last night was the very first night that I
+have ever slept without a nurse in the room. I was so much better
+that I thought I could dispense with one. I had a night-light
+burning, however. Well, about two in the morning I had sunk into
+a light sleep when I was suddenly aroused by a slight noise. It
+was like the sound which a mouse makes when it is gnawing a
+plank, and I lay listening to it for some time under the
+impression that it must come from that cause. Then it grew
+louder, and suddenly there came from the window a sharp metallic
+snick. I sat up in amazement. There could be no doubt what the
+sounds were now. The first ones had been caused by some one
+forcing an instrument through the slit between the sashes, and
+the second by the catch being pressed back.
+
+“There was a pause then for about ten minutes, as if the person
+were waiting to see whether the noise had awakened me. Then I
+heard a gentle creaking as the window was very slowly opened. I
+could stand it no longer, for my nerves are not what they used to
+be. I sprang out of bed and flung open the shutters. A man was
+crouching at the window. I could see little of him, for he was
+gone like a flash. He was wrapped in some sort of cloak which
+came across the lower part of his face. One thing only I am sure
+of, and that is that he had some weapon in his hand. It looked to
+me like a long knife. I distinctly saw the gleam of it as he
+turned to run.”
+
+“This is most interesting,” said Holmes. “Pray what did you do
+then?”
+
+“I should have followed him through the open window if I had been
+stronger. As it was, I rang the bell and roused the house. It
+took me some little time, for the bell rings in the kitchen and
+the servants all sleep upstairs. I shouted, however, and that
+brought Joseph down, and he roused the others. Joseph and the
+groom found marks on the bed outside the window, but the weather
+has been so dry lately that they found it hopeless to follow the
+trail across the grass. There’s a place, however, on the wooden
+fence which skirts the road which shows signs, they tell me, as
+if some one had got over, and had snapped the top of the rail in
+doing so. I have said nothing to the local police yet, for I
+thought I had best have your opinion first.”
+
+This tale of our client’s appeared to have an extraordinary
+effect upon Sherlock Holmes. He rose from his chair and paced
+about the room in uncontrollable excitement.
+
+“Misfortunes never come single,” said Phelps, smiling, though it
+was evident that his adventure had somewhat shaken him.
+
+“You have certainly had your share,” said Holmes. “Do you think
+you could walk round the house with me?”
+
+“Oh, yes, I should like a little sunshine. Joseph will come,
+too.”
+
+“And I also,” said Miss Harrison.
+
+“I am afraid not,” said Holmes, shaking his head. “I think I must
+ask you to remain sitting exactly where you are.”
+
+The young lady resumed her seat with an air of displeasure. Her
+brother, however, had joined us and we set off all four together.
+We passed round the lawn to the outside of the young
+diplomatist’s window. There were, as he had said, marks upon the
+bed, but they were hopelessly blurred and vague. Holmes stopped
+over them for an instant, and then rose shrugging his shoulders.
+
+“I don’t think any one could make much of this,” said he. “Let us
+go round the house and see why this particular room was chosen by
+the burglar. I should have thought those larger windows of the
+drawing-room and dining-room would have had more attractions for
+him.”
+
+“They are more visible from the road,” suggested Mr. Joseph
+Harrison.
+
+“Ah, yes, of course. There is a door here which he might have
+attempted. What is it for?”
+
+“It is the side entrance for trades-people. Of course it is
+locked at night.”
+
+“Have you ever had an alarm like this before?”
+
+“Never,” said our client.
+
+“Do you keep plate in the house, or anything to attract
+burglars?”
+
+“Nothing of value.”
+
+Holmes strolled round the house with his hands in his pockets and
+a negligent air which was unusual with him.
+
+“By the way,” said he to Joseph Harrison, “you found some place,
+I understand, where the fellow scaled the fence. Let us have a
+look at that!”
+
+The plump young man led us to a spot where the top of one of the
+wooden rails had been cracked. A small fragment of the wood was
+hanging down. Holmes pulled it off and examined it critically.
+
+“Do you think that was done last night? It looks rather old, does
+it not?”
+
+“Well, possibly so.”
+
+“There are no marks of any one jumping down upon the other side.
+No, I fancy we shall get no help here. Let us go back to the
+bedroom and talk the matter over.”
+
+Percy Phelps was walking very slowly, leaning upon the arm of his
+future brother-in-law. Holmes walked swiftly across the lawn, and
+we were at the open window of the bedroom long before the others
+came up.
+
+“Miss Harrison,” said Holmes, speaking with the utmost intensity
+of manner, “you must stay where you are all day. Let nothing
+prevent you from staying where you are all day. It is of the
+utmost importance.”
+
+“Certainly, if you wish it, Mr. Holmes,” said the girl in
+astonishment.
+
+“When you go to bed lock the door of this room on the outside and
+keep the key. Promise to do this.”
+
+“But Percy?”
+
+“He will come to London with us.”
+
+“And am I to remain here?”
+
+“It is for his sake. You can serve him. Quick! Promise!”
+
+She gave a quick nod of assent just as the other two came up.
+
+“Why do you sit moping there, Annie?” cried her brother. “Come
+out into the sunshine!”
+
+“No, thank you, Joseph. I have a slight headache and this room is
+deliciously cool and soothing.”
+
+“What do you propose now, Mr. Holmes?” asked our client.
+
+“Well, in investigating this minor affair we must not lose sight
+of our main inquiry. It would be a very great help to me if you
+would come up to London with us.”
+
+“At once?”
+
+“Well, as soon as you conveniently can. Say in an hour.”
+
+“I feel quite strong enough, if I can really be of any help.”
+
+“The greatest possible.”
+
+“Perhaps you would like me to stay there to-night?”
+
+“I was just going to propose it.”
+
+“Then, if my friend of the night comes to revisit me, he will
+find the bird flown. We are all in your hands, Mr. Holmes, and
+you must tell us exactly what you would like done. Perhaps you
+would prefer that Joseph came with us so as to look after me?”
+
+“Oh, no; my friend Watson is a medical man, you know, and he’ll
+look after you. We’ll have our lunch here, if you will permit us,
+and then we shall all three set off for town together.”
+
+It was arranged as he suggested, though Miss Harrison excused
+herself from leaving the bedroom, in accordance with Holmes’s
+suggestion. What the object of my friend’s manœuvres was I could
+not conceive, unless it were to keep the lady away from Phelps,
+who, rejoiced by his returning health and by the prospect of
+action, lunched with us in the dining-room. Holmes had a still
+more startling surprise for us, however, for, after accompanying
+us down to the station and seeing us into our carriage, he calmly
+announced that he had no intention of leaving Woking.
+
+“There are one or two small points which I should desire to clear
+up before I go,” said he. “Your absence, Mr. Phelps, will in some
+ways rather assist me. Watson, when you reach London you would
+oblige me by driving at once to Baker Street with our friend
+here, and remaining with him until I see you again. It is
+fortunate that you are old schoolfellows, as you must have much
+to talk over. Mr. Phelps can have the spare bedroom to-night, and
+I will be with you in time for breakfast, for there is a train
+which will take me into Waterloo at eight.”
+
+“But how about our investigation in London?” asked Phelps,
+ruefully.
+
+“We can do that to-morrow. I think that just at present I can be
+of more immediate use here.”
+
+“You might tell them at Briarbrae that I hope to be back
+to-morrow night,” cried Phelps, as we began to move from the
+platform.
+
+“I hardly expect to go back to Briarbrae,” answered Holmes, and
+waved his hand to us cheerily as we shot out from the station.
+
+Phelps and I talked it over on our journey, but neither of us
+could devise a satisfactory reason for this new development.
+
+“I suppose he wants to find out some clue as to the burglary last
+night, if a burglar it was. For myself, I don’t believe it was an
+ordinary thief.”
+
+“What is your own idea, then?”
+
+“Upon my word, you may put it down to my weak nerves or not, but
+I believe there is some deep political intrigue going on around
+me, and that for some reason that passes my understanding my life
+is aimed at by the conspirators. It sounds high-flown and absurd,
+but consider the facts! Why should a thief try to break in at a
+bedroom window, where there could be no hope of any plunder, and
+why should he come with a long knife in his hand?”
+
+“You are sure it was not a house-breaker’s jimmy?”
+
+“Oh, no, it was a knife. I saw the flash of the blade quite
+distinctly.”
+
+“But why on earth should you be pursued with such animosity?”
+
+“Ah, that is the question.”
+
+“Well, if Holmes takes the same view, that would account for his
+action, would it not? Presuming that your theory is correct, if
+he can lay his hands upon the man who threatened you last night
+he will have gone a long way towards finding who took the naval
+treaty. It is absurd to suppose that you have two enemies, one of
+whom robs you, while the other threatens your life.”
+
+“But Holmes said that he was not going to Briarbrae.”
+
+“I have known him for some time,” said I, “but I never knew him
+do anything yet without a very good reason,” and with that our
+conversation drifted off on to other topics.
+
+But it was a weary day for me. Phelps was still weak after his
+long illness, and his misfortune made him querulous and nervous.
+In vain I endeavoured to interest him in Afghanistan, in India,
+in social questions, in anything which might take his mind out of
+the groove. He would always come back to his lost treaty,
+wondering, guessing, speculating, as to what Holmes was doing,
+what steps Lord Holdhurst was taking, what news we should have in
+the morning. As the evening wore on his excitement became quite
+painful.
+
+“You have implicit faith in Holmes?” he asked.
+
+“I have seen him do some remarkable things.”
+
+“But he never brought light into anything quite so dark as this?”
+
+“Oh, yes; I have known him solve questions which presented fewer
+clues than yours.”
+
+“But not where such large interests are at stake?”
+
+“I don’t know that. To my certain knowledge he has acted on
+behalf of three of the reigning houses of Europe in very vital
+matters.”
+
+“But you know him well, Watson. He is such an inscrutable fellow
+that I never quite know what to make of him. Do you think he is
+hopeful? Do you think he expects to make a success of it?”
+
+“He has said nothing.”
+
+“That is a bad sign.”
+
+“On the contrary, I have noticed that when he is off the trail he
+generally says so. It is when he is on a scent and is not quite
+absolutely sure yet that it is the right one that he is most
+taciturn. Now, my dear fellow, we can’t help matters by making
+ourselves nervous about them, so let me implore you to go to bed
+and so be fresh for whatever may await us to-morrow.”
+
+I was able at last to persuade my companion to take my advice,
+though I knew from his excited manner that there was not much
+hope of sleep for him. Indeed, his mood was infectious, for I lay
+tossing half the night myself, brooding over this strange
+problem, and inventing a hundred theories, each of which was more
+impossible than the last. Why had Holmes remained at Woking? Why
+had he asked Miss Harrison to remain in the sick-room all day?
+Why had he been so careful not to inform the people at Briarbrae
+that he intended to remain near them? I cudgelled my brains until
+I fell asleep in the endeavour to find some explanation which
+would cover all these facts.
+
+It was seven o’clock when I awoke, and I set off at once for
+Phelps’s room, to find him haggard and spent after a sleepless
+night. His first question was whether Holmes had arrived yet.
+
+“He’ll be here when he promised,” said I, “and not an instant
+sooner or later.”
+
+And my words were true, for shortly after eight a hansom dashed
+up to the door and our friend got out of it. Standing in the
+window we saw that his left hand was swathed in a bandage and
+that his face was very grim and pale. He entered the house, but
+it was some little time before he came upstairs.
+
+“He looks like a beaten man,” cried Phelps.
+
+I was forced to confess that he was right. “After all,” said I,
+“the clue of the matter lies probably here in town.”
+
+Phelps gave a groan.
+
+“I don’t know how it is,” said he, “but I had hoped for so much
+from his return. But surely his hand was not tied up like that
+yesterday. What can be the matter?”
+
+“You are not wounded, Holmes?” I asked, as my friend entered the
+room.
+
+“Tut, it is only a scratch through my own clumsiness,” he
+answered, nodding his good-mornings to us. “This case of yours,
+Mr. Phelps, is certainly one of the darkest which I have ever
+investigated.”
+
+“I feared that you would find it beyond you.”
+
+“It has been a most remarkable experience.”
+
+“That bandage tells of adventures,” said I. “Won’t you tell us
+what has happened?”
+
+“After breakfast, my dear Watson. Remember that I have breathed
+thirty miles of Surrey air this morning. I suppose that there has
+been no answer from my cabman advertisement? Well, well, we
+cannot expect to score every time.”
+
+The table was all laid, and just as I was about to ring Mrs.
+Hudson entered with the tea and coffee. A few minutes later she
+brought in three covers, and we all drew up to the table, Holmes
+ravenous, I curious, and Phelps in the gloomiest state of
+depression.
+
+“Mrs. Hudson has risen to the occasion,” said Holmes, uncovering
+a dish of curried chicken. “Her cuisine is a little limited, but
+she has as good an idea of breakfast as a Scotch-woman. What have
+you here, Watson?”
+
+“Ham and eggs,” I answered.
+
+“Good! What are you going to take, Mr. Phelps—curried fowl or
+eggs, or will you help yourself?”
+
+“Thank you. I can eat nothing,” said Phelps.
+
+“Oh, come! Try the dish before you.”
+
+“Thank you, I would really rather not.”
+
+“Well, then,” said Holmes, with a mischievous twinkle, “I suppose
+that you have no objection to helping me?”
+
+Phelps raised the cover, and as he did so he uttered a scream,
+and sat there staring with a face as white as the plate upon
+which he looked. Across the centre of it was lying a little
+cylinder of blue-grey paper. He caught it up, devoured it with
+his eyes, and then danced madly about the room, pressing it to
+his bosom and shrieking out in his delight. Then he fell back
+into an armchair so limp and exhausted with his own emotions that
+we had to pour brandy down his throat to keep him from fainting.
+
+“There! there!” said Holmes, soothing, patting him upon the
+shoulder. “It was too bad to spring it on you like this, but
+Watson here will tell you that I never can resist a touch of the
+dramatic.”
+
+Phelps seized his hand and kissed it. “God bless you!” he cried.
+“You have saved my honour.”
+
+“Well, my own was at stake, you know,” said Holmes. “I assure you
+it is just as hateful to me to fail in a case as it can be to you
+to blunder over a commission.”
+
+Phelps thrust away the precious document into the innermost
+pocket of his coat.
+
+“I have not the heart to interrupt your breakfast any further,
+and yet I am dying to know how you got it and where it was.”
+
+Sherlock Holmes swallowed a cup of coffee, and turned his
+attention to the ham and eggs. Then he rose, lit his pipe, and
+settled himself down into his chair.
+
+“I’ll tell you what I did first, and how I came to do it
+afterwards,” said he. “After leaving you at the station I went
+for a charming walk through some admirable Surrey scenery to a
+pretty little village called Ripley, where I had my tea at an
+inn, and took the precaution of filling my flask and of putting a
+paper of sandwiches in my pocket. There I remained until evening,
+when I set off for Woking again, and found myself in the
+high-road outside Briarbrae just after sunset.
+
+“Well, I waited until the road was clear—it is never a very
+frequented one at any time, I fancy—and then I clambered over the
+fence into the grounds.”
+
+“Surely the gate was open!” ejaculated Phelps.
+
+“Yes, but I have a peculiar taste in these matters. I chose the
+place where the three fir-trees stand, and behind their screen I
+got over without the least chance of any one in the house being
+able to see me. I crouched down among the bushes on the other
+side, and crawled from one to the other—witness the disreputable
+state of my trouser knees—until I had reached the clump of
+rhododendrons just opposite to your bedroom window. There I
+squatted down and awaited developments.
+
+“The blind was not down in your room, and I could see Miss
+Harrison sitting there reading by the table. It was quarter-past
+ten when she closed her book, fastened the shutters, and retired.
+
+“I heard her shut the door, and felt quite sure that she had
+turned the key in the lock.”
+
+“The key!” ejaculated Phelps.
+
+“Yes; I had given Miss Harrison instructions to lock the door on
+the outside and take the key with her when she went to bed. She
+carried out every one of my injunctions to the letter, and
+certainly without her co-operation you would not have that paper
+in your coat-pocket. She departed then and the lights went out,
+and I was left squatting in the rhododendron-bush.
+
+“The night was fine, but still it was a very weary vigil. Of
+course it has the sort of excitement about it that the sportsman
+feels when he lies beside the water-course and waits for the big
+game. It was very long, though—almost as long, Watson, as when
+you and I waited in that deadly room when we looked into the
+little problem of the Speckled Band. There was a church-clock
+down at Woking which struck the quarters, and I thought more than
+once that it had stopped. At last however about two in the
+morning, I suddenly heard the gentle sound of a bolt being pushed
+back and the creaking of a key. A moment later the servants’ door
+was opened, and Mr. Joseph Harrison stepped out into the
+moonlight.”
+
+“Joseph!” ejaculated Phelps.
+
+“He was bare-headed, but he had a black coat thrown over his
+shoulder so that he could conceal his face in an instant if there
+were any alarm. He walked on tiptoe under the shadow of the wall,
+and when he reached the window he worked a long-bladed knife
+through the sash and pushed back the catch. Then he flung open
+the window, and putting his knife through the crack in the
+shutters, he thrust the bar up and swung them open.
+
+“From where I lay I had a perfect view of the inside of the room
+and of every one of his movements. He lit the two candles which
+stood upon the mantelpiece, and then he proceeded to turn back
+the corner of the carpet in the neighbourhood of the door.
+Presently he stopped and picked out a square piece of board, such
+as is usually left to enable plumbers to get at the joints of the
+gas-pipes. This one covered, as a matter of fact, the T joint
+which gives off the pipe which supplies the kitchen underneath.
+Out of this hiding-place he drew that little cylinder of paper,
+pushed down the board, rearranged the carpet, blew out the
+candles, and walked straight into my arms as I stood waiting for
+him outside the window.
+
+“Well, he has rather more viciousness than I gave him credit for,
+has Master Joseph. He flew at me with his knife, and I had to
+grasp him twice, and got a cut over the knuckles, before I had
+the upper hand of him. He looked murder out of the only eye he
+could see with when we had finished, but he listened to reason
+and gave up the papers. Having got them I let my man go, but I
+wired full particulars to Forbes this morning. If he is quick
+enough to catch his bird, well and good. But if, as I shrewdly
+suspect, he finds the nest empty before he gets there, why, all
+the better for the government. I fancy that Lord Holdhurst for
+one, and Mr. Percy Phelps for another, would very much rather
+that the affair never got as far as a police-court.
+
+“My God!” gasped our client. “Do you tell me that during these
+long ten weeks of agony the stolen papers were within the very
+room with me all the time?”
+
+“So it was.”
+
+“And Joseph! Joseph a villain and a thief!”
+
+“Hum! I am afraid Joseph’s character is a rather deeper and more
+dangerous one than one might judge from his appearance. From what
+I have heard from him this morning, I gather that he has lost
+heavily in dabbling with stocks, and that he is ready to do
+anything on earth to better his fortunes. Being an absolutely
+selfish man, when a chance presented itself he did not allow
+either his sister’s happiness or your reputation to hold his
+hand.”
+
+Percy Phelps sank back in his chair. “My head whirls,” said he.
+“Your words have dazed me.”
+
+“The principal difficulty in your case,” remarked Holmes, in his
+didactic fashion, “lay in the fact of there being too much
+evidence. What was vital was overlaid and hidden by what was
+irrelevant. Of all the facts which were presented to us we had to
+pick just those which we deemed to be essential, and then piece
+them together in their order, so as to reconstruct this very
+remarkable chain of events. I had already begun to suspect
+Joseph, from the fact that you had intended to travel home with
+him that night, and that therefore it was a likely enough thing
+that he should call for you, knowing the Foreign Office well,
+upon his way. When I heard that some one had been so anxious to
+get into the bedroom, in which no one but Joseph could have
+concealed anything—you told us in your narrative how you had
+turned Joseph out when you arrived with the doctor—my suspicions
+all changed to certainties, especially as the attempt was made on
+the first night upon which the nurse was absent, showing that the
+intruder was well acquainted with the ways of the house.”
+
+“How blind I have been!”
+
+“The facts of the case, as far as I have worked them out, are
+these: this Joseph Harrison entered the office through the
+Charles Street door, and knowing his way he walked straight into
+your room the instant after you left it. Finding no one there he
+promptly rang the bell, and at the instant that he did so his
+eyes caught the paper upon the table. A glance showed him that
+chance had put in his way a State document of immense value, and
+in an instant he had thrust it into his pocket and was gone. A
+few minutes elapsed, as you remember, before the sleepy
+commissionnaire drew your attention to the bell, and those were
+just enough to give the thief time to make his escape.
+
+“He made his way to Woking by the first train, and having
+examined his booty and assured himself that it really was of
+immense value, he had concealed it in what he thought was a very
+safe place, with the intention of taking it out again in a day or
+two, and carrying it to the French embassy, or wherever he
+thought that a long price was to be had. Then came your sudden
+return. He, without a moment’s warning, was bundled out of his
+room, and from that time onward there were always at least two of
+you there to prevent him from regaining his treasure. The
+situation to him must have been a maddening one. But at last he
+thought he saw his chance. He tried to steal in, but was baffled
+by your wakefulness. You remember that you did not take your
+usual draught that night.”
+
+“I remember.”
+
+“I fancy that he had taken steps to make that draught
+efficacious, and that he quite relied upon your being
+unconscious. Of course, I understood that he would repeat the
+attempt whenever it could be done with safety. Your leaving the
+room gave him the chance he wanted. I kept Miss Harrison in it
+all day so that he might not anticipate us. Then, having given
+him the idea that the coast was clear, I kept guard as I have
+described. I already knew that the papers were probably in the
+room, but I had no desire to rip up all the planking and skirting
+in search of them. I let him take them, therefore, from the
+hiding-place, and so saved myself an infinity of trouble. Is
+there any other point which I can make clear?”
+
+“Why did he try the window on the first occasion,” I asked, “when
+he might have entered by the door?”
+
+“In reaching the door he would have to pass seven bedrooms. On
+the other hand, he could get out on to the lawn with ease.
+Anything else?”
+
+“You do not think,” asked Phelps, “that he had any murderous
+intention? The knife was only meant as a tool.”
+
+“It may be so,” answered Holmes, shrugging his shoulders. “I can
+only say for certain that Mr. Joseph Harrison is a gentleman to
+whose mercy I should be extremely unwilling to trust.”

--- a/examples/The Red Headed League.txt
+++ b/examples/The Red Headed League.txt
@@ -1,0 +1,1041 @@
+The Red Headed League
+
+
+I had called upon my friend, Mr. Sherlock Holmes, one day in the autumn
+of last year, and found him in deep conversation with a very stout,
+florid-faced, elderly gentleman, with fiery red hair. With an apology
+for my intrusion, I was about to withdraw, when Holmes pulled me
+abruptly into the room and closed the door behind me.
+
+“You could not possibly have come at a better time, my dear Watson,” he
+said, cordially.
+
+“I was afraid that you were engaged.”
+
+“So I am. Very much so.”
+
+“Then I can wait in the next room.”
+
+“Not at all. This gentleman, Mr. Wilson, has been my partner and helper
+in many of my most successful cases, and I have no doubt that he will
+be of the utmost use to me in yours also.”
+
+The stout gentleman half-rose from his chair and gave a bob of
+greeting, with a quick, little, questioning glance from his small,
+fat-encircled eyes.
+
+“Try the settee,” said Holmes, relapsing into his arm-chair and putting
+his finger-tips together, as was his custom when in judicial moods. “I
+know, my dear Watson, that you share my love of all that is bizarre and
+outside the conventions and humdrum routine of every-day life. You have
+shown your relish for it by the enthusiasm which has prompted you to
+chronicle, and, if you will excuse my saying so, somewhat to embellish
+so many of my own little adventures.”
+
+“Your cases have indeed been of the greatest interest to me,” I
+observed.
+
+“You will remember that I remarked the other day, just before we went
+into the very simple problem presented by Miss Mary Sutherland, that
+for strange effects and extraordinary combinations we must go to
+life itself, which is always far more daring than any effort of the
+imagination.”
+
+“A proposition which I took the liberty of doubting.”
+
+“You did, doctor, but none the less you must come round to my view,
+for otherwise I shall keep on piling fact upon fact on you, until your
+reason breaks down under them and acknowledges me to be right. Now, Mr.
+Jabez Wilson here has been good enough to call upon me this morning,
+and to begin a narrative which promises to be one of the most singular
+which I have listened to for some time. You have heard me remark that
+the strangest and most unique things are very often connected not with
+the larger but with the smaller crimes, and occasionally, indeed, where
+there is room for doubt whether any positive crime has been committed.
+As far as I have heard it is impossible for me to say whether the
+present case is an instance of crime or not, but the course of events
+is certainly among the most singular that I have ever listened to.
+Perhaps, Mr. Wilson, you would have the great kindness to recommence
+your narrative. I ask you, not merely because my friend Dr. Watson has
+not heard the opening part, but also because the peculiar nature of the
+story makes me anxious to have every possible detail from your lips.
+As a rule, when I have heard some slight indication of the course of
+events, I am able to guide myself by the thousands of other similar
+cases which occur to my memory. In the present instance I am forced to
+admit that the facts are, to the best of my belief, unique.”
+
+The portly client puffed out his chest with an appearance of some
+little pride, and pulled a dirty and wrinkled newspaper from the inside
+pocket of his great-coat. As he glanced down the advertisement column,
+with his head thrust forward, and the paper flattened out upon his
+knee, I took a good look at the man, and endeavored, after the fashion
+of my companion, to read the indications which might be presented by
+his dress or appearance.
+
+I did not gain very much, however, by my inspection. Our visitor bore
+every mark of being an average commonplace British tradesman, obese,
+pompous, and slow. He wore rather baggy gray shepherd’s check trousers,
+a not over-clean black frock-coat, unbuttoned in the front, and a drab
+waistcoat with a heavy brassy Albert chain, and a square pierced bit of
+metal dangling down as an ornament. A frayed top-hat and a faded brown
+overcoat with a wrinkled velvet collar lay upon a chair beside him.
+Altogether, look as I would, there was nothing remarkable about the man
+save his blazing red head, and the expression of extreme chagrin and
+discontent upon his features.
+
+Sherlock Holmes’s quick eye took in my occupation, and he shook his
+head with a smile as he noticed my questioning glances. “Beyond the
+obvious facts that he has at some time done manual labor, that he takes
+snuff, that he is a Freemason, that he has been in China, and that he
+has done a considerable amount of writing lately, I can deduce nothing
+else.”
+
+Mr. Jabez Wilson started up in his chair, with his forefinger upon the
+paper, but his eyes upon my companion.
+
+“How, in the name of good-fortune, did you know all that, Mr. Holmes?”
+he asked. “How did you know, for example, that I did manual labor. It’s
+as true as gospel, for I began as a ship’s carpenter.”
+
+“Your hands, my dear sir. Your right hand is quite a size larger than
+your left. You have worked with it, and the muscles are more developed.”
+
+“Well, the snuff, then, and the Freemasonry?”
+
+“I won’t insult your intelligence by telling you how I read that,
+especially as, rather against the strict rules of your order, you use
+an arc-and-compass breastpin.”
+
+“Ah, of course, I forgot that. But the writing?”
+
+“What else can be indicated by that right cuff so very shiny for five
+inches, and the left one with the smooth patch near the elbow where you
+rest it upon the desk.”
+
+“Well, but China?”
+
+“The fish that you have tattooed immediately above your right wrist
+could only have been done in China. I have made a small study of tattoo
+marks, and have even contributed to the literature of the subject.
+That trick of staining the fishes’ scales of a delicate pink is quite
+peculiar to China. When, in addition, I see a Chinese coin hanging from
+your watch-chain, the matter becomes even more simple.”
+
+Mr. Jabez Wilson laughed heavily. “Well, I never!” said he. “I thought
+at first that you had done something clever, but I see that there was
+nothing in it, after all.”
+
+“I begin to think, Watson,” said Holmes, “that I make a mistake in
+explaining. ‘Omne ignotum pro magnifico,’ you know, and my poor little
+reputation, such as it is, will suffer shipwreck if I am so candid. Can
+you not find the advertisement, Mr. Wilson?”
+
+“Yes, I have got it now,” he answered, with his thick, red finger
+planted half-way down the column. “Here it is. This is what began it
+all. You just read it for yourself, sir.”
+
+I took the paper from him, and read as follows:
+
+  “TO THE RED-HEADED LEAGUE: On account of the bequest of the
+  late Ezekiah Hopkins, of Lebanon, Pa., U.S.A., there is now
+  another vacancy open which entitles a member of the League
+  to a salary of £4 a week for purely nominal services. All
+  red-headed men who are sound in body and mind, and above
+  the age of twenty-one years, are eligible. Apply in person on
+  Monday, at eleven o’clock, to Duncan Ross, at the offices of
+  the League, 7 Pope’s Court, Fleet Street.”
+
+“What on earth does this mean?” I ejaculated, after I had twice read
+over the extraordinary announcement.
+
+Holmes chuckled, and wriggled in his chair, as was his habit when in
+high spirits. “It is a little off the beaten track, isn’t it?” said
+he. “And now, Mr. Wilson, off you go at scratch, and tell us all about
+yourself, your household, and the effect which this advertisement had
+upon your fortunes. You will first make a note, doctor, of the paper
+and the date.”
+
+“It is _The Morning Chronicle_, of April 27, 1890. Just two months ago.”
+
+“Very good. Now, Mr. Wilson?”
+
+“Well, it is just as I have been telling you, Mr. Sherlock Holmes,”
+said Jabez Wilson, mopping his forehead; “I have a small pawnbroker’s
+business at Coburg Square, near the city. It’s not a very large affair,
+and of late years it has not done more than just give me a living. I
+used to be able to keep two assistants, but now I only keep one; and I
+would have a job to pay him, but that he is willing to come for half
+wages, so as to learn the business.”
+
+“What is the name of this obliging youth?” asked Sherlock Holmes.
+
+“His name is Vincent Spaulding, and he’s not such a youth, either. It’s
+hard to say his age. I should not wish a smarter assistant, Mr. Holmes;
+and I know very well that he could better himself, and earn twice what
+I am able to give him. But, after all, if he is satisfied, why should I
+put ideas in his head?”
+
+“Why, indeed? You seem most fortunate in having an _employé_ who
+comes under the full market price. It is not a common experience among
+employers in this age. I don’t know that your assistant is not as
+remarkable as your advertisement.”
+
+“Oh, he has his faults, too,” said Mr. Wilson. “Never was such a fellow
+for photography. Snapping away with a camera when he ought to be
+improving his mind, and then diving down into the cellar like a rabbit
+into its hole to develope his pictures. That is his main fault; but, on
+the whole, he’s a good worker. There’s no vice in him.”
+
+“He is still with you, I presume?”
+
+“Yes, sir. He and a girl of fourteen, who does a bit of simple cooking,
+and keeps the place clean—that’s all I have in the house, for I am a
+widower, and never had any family. We live very quietly, sir, the three
+of us; and we keep a roof over our heads, and pay our debts, if we do
+nothing more.
+
+“The first thing that put us out was that advertisement. Spaulding, he
+came down into the office just this day eight weeks, with this very
+paper in his hand, and he says:
+
+“‘I wish to the Lord, Mr. Wilson, that I was a red-headed man.’
+
+“‘Why that?’ I asks.
+
+“‘Why,’ says he, ‘here’s another vacancy on the League of the
+Red-headed Men. It’s worth quite a little fortune to any man who gets
+it, and I understand that there are more vacancies than there are men,
+so that the trustees are at their wits’ end what to do with the money.
+If my hair would only change color, here’s a nice little crib all ready
+for me to step into.’
+
+“‘Why, what is it, then?’ I asked. You see, Mr. Holmes, I am a very
+stay-at-home man, and as my business came to me instead of my having
+to go to it, I was often weeks on end without putting my foot over the
+door-mat. In that way I didn’t know much of what was going on outside,
+and I was always glad of a bit of news.
+
+“‘Have you never heard of the League of the Red-headed Men?’ he asked,
+with his eyes open.
+
+“‘Never.’
+
+“‘Why, I wonder at that, for you are eligible yourself for one of the
+vacancies.’
+
+“‘And what are they worth?’ I asked.
+
+“‘Oh, merely a couple of hundred a year, but the work is slight, and it
+need not interfere very much with one’s other occupations.’
+
+“Well, you can easily think that that made me prick up my ears, for the
+business has not been over-good for some years, and an extra couple of
+hundred would have been very handy.
+
+“‘Tell me all about it,’ said I.
+
+“‘Well,’ said he, showing me the advertisement, ‘you can see for
+yourself that the League has a vacancy, and there is the address
+where you should apply for particulars. As far as I can make out, the
+League was founded by an American millionaire, Ezekiah Hopkins, who
+was very peculiar in his ways. He was himself red-headed, and he had a
+great sympathy for all red-headed men; so, when he died, it was found
+that he had left his enormous fortune in the hands of trustees, with
+instructions to apply the interest to the providing of easy berths to
+men whose hair is of that color. From all I hear it is splendid pay,
+and very little to do.’
+
+“‘But,’ said I, ‘there would be millions of red-headed men who would
+apply.’
+
+“‘Not so many as you might think,’ he answered. ‘You see it is really
+confined to Londoners, and to grown men. This American had started from
+London when he was young, and he wanted to do the old town a good turn.
+Then, again, I have heard it is no use your applying if your hair is
+light red, or dark red, or anything but real bright, blazing, fiery
+red. Now, if you cared to apply, Mr. Wilson, you would just walk in;
+but perhaps it would hardly be worth your while to put yourself out of
+the way for the sake of a few hundred pounds.’
+
+“Now, it is a fact, gentlemen, as you may see for yourselves, that my
+hair is of a very full and rich tint, so that it seemed to me that, if
+there was to be any competition in the matter, I stood as good a chance
+as any man that I had ever met. Vincent Spaulding seemed to know so
+much about it that I thought he might prove useful, so I just ordered
+him to put up the shutters for the day, and to come right away with me.
+He was very willing to have a holiday, so we shut the business up, and
+started off for the address that was given us in the advertisement.
+
+“I never hope to see such a sight as that again, Mr. Holmes. From
+north, south, east, and west every man who had a shade of red in his
+hair had tramped into the city to answer the advertisement. Fleet
+Street was choked with red-headed folk, and Pope’s Court looked
+like a coster’s orange barrow. I should not have thought there were
+so many in the whole country as were brought together by that single
+advertisement. Every shade of color they were—straw, lemon, orange,
+brick, Irish-setter, liver, clay; but, as Spaulding said, there were
+not many who had the real vivid flame-colored tint. When I saw how many
+were waiting, I would have given it up in despair; but Spaulding would
+not hear of it. How he did it I could not imagine, but he pushed and
+pulled and butted until he got me through the crowd, and right up to
+the steps which led to the office. There was a double stream upon the
+stair, some going up in hope, and some coming back dejected; but we
+wedged in as well as we could, and soon found ourselves in the office.”
+
+“Your experience has been a most entertaining one,” remarked Holmes, as
+his client paused and refreshed his memory with a huge pinch of snuff.
+“Pray continue your very interesting statement.”
+
+“There was nothing in the office but a couple of wooden chairs and a
+deal table, behind which sat a small man, with a head that was even
+redder than mine. He said a few words to each candidate as he came
+up, and then he always managed to find some fault in them which would
+disqualify them. Getting a vacancy did not seem to be such a very easy
+matter, after all. However, when our turn came, the little man was much
+more favorable to me than to any of the others, and he closed the door
+as we entered, so that he might have a private word with us.
+
+“‘This is Mr. Jabez Wilson,’ said my assistant, ‘and he is willing to
+fill a vacancy in the League.’
+
+“‘And he is admirably suited for it,’ the other answered. ‘He has every
+requirement. I cannot recall when I have seen anything so fine.’ He
+took a step backward, cocked his head on one side, and gazed at my hair
+until I felt quite bashful. Then suddenly he plunged forward, wrung my
+hand, and congratulated me warmly on my success.
+
+“‘It would be injustice to hesitate,’ said he. ‘You will, however, I am
+sure, excuse me for taking an obvious precaution.’ With that he seized
+my hair in both his hands, and tugged until I yelled with the pain.
+‘There is water in your eyes,’ said he, as he released me. ‘I perceive
+that all is as it should be. But we have to be careful, for we have
+twice been deceived by wigs and once by paint. I could tell you tales
+of cobbler’s wax which would disgust you with human nature.’ He stepped
+over to the window, and shouted through it at the top of his voice that
+the vacancy was filled. A groan of disappointment came up from below,
+and the folk all trooped away in different directions, until there was
+not a red head to be seen except my own and that of the manager.
+
+“‘My name,’ said he, ‘is Mr. Duncan Ross, and I am myself one of the
+pensioners upon the fund left by our noble benefactor. Are you a
+married man, Mr. Wilson? Have you a family?’
+
+“I answered that I had not.
+
+“His face fell immediately.
+
+“‘Dear me!’ he said, gravely, ‘that is very serious indeed! I am sorry
+to hear you say that. The fund was, of course, for the propagation
+and spread of the red-heads as well as for their maintenance. It is
+exceedingly unfortunate that you should be a bachelor.’
+
+“My face lengthened at this, Mr. Holmes, for I thought that I was not
+to have the vacancy after all; but, after thinking it over for a few
+minutes, he said that it would be all right.
+
+“‘In the case of another,’ said he, ‘the objection might be fatal, but
+we must stretch a point in favor of a man with such a head of hair as
+yours. When shall you be able to enter upon your new duties?’
+
+“‘Well, it is a little awkward, for I have a business already,’ said I.
+
+“‘Oh, never mind about that, Mr. Wilson!’ said Vincent Spaulding. ‘I
+shall be able to look after that for you.’
+
+“‘What would be the hours?’ I asked.
+
+“‘Ten to two.’
+
+“Now a pawnbroker’s business is mostly done of an evening, Mr. Holmes,
+especially Thursday and Friday evening, which is just before pay-day;
+so it would suit me very well to earn a little in the mornings.
+Besides, I knew that my assistant was a good man, and that he would see
+to anything that turned up.
+
+“‘That would suit me very well,’ said I. ‘And the pay?’
+
+“‘Is £4 a week.’
+
+“‘And the work?’
+
+“‘Is purely nominal.’
+
+“‘What do you call purely nominal?’
+
+“‘Well, you have to be in the office, or at least in the building, the
+whole time. If you leave, you forfeit your whole position forever.
+The will is very clear upon that point. You don’t comply with the
+conditions if you budge from the office during that time.’
+
+“‘It’s only four hours a day, and I should not think of leaving,’ said
+I.
+
+“‘No excuse will avail,’ said Mr. Duncan Ross, ‘neither sickness nor
+business nor anything else. There you must stay, or you lose your
+billet.’
+
+“‘And the work?’
+
+“‘Is to copy out the “Encyclopædia Britannica.” There is the first
+volume of it in that press. You must find your own ink, pens, and
+blotting-paper, but we provide this table and chair. Will you be ready
+to-morrow?’
+
+“‘Certainly,’ I answered.
+
+“‘Then, good-bye, Mr. Jabez Wilson, and let me congratulate you once
+more on the important position which you have been fortunate enough to
+gain.’ He bowed me out of the room, and I went home with my assistant,
+hardly knowing what to say or do, I was so pleased at my own good
+fortune.
+
+“Well, I thought over the matter all day, and by evening I was in
+low spirits again; for I had quite persuaded myself that the whole
+affair must be some great hoax or fraud, though what its object might
+be I could not imagine. It seemed altogether past belief that any one
+could make such a will, or that they would pay such a sum for doing
+anything so simple as copying out the ‘Encyclopædia Britannica.’
+Vincent Spaulding did what he could to cheer me up, but by bedtime I
+had reasoned myself out of the whole thing. However, in the morning
+I determined to have a look at it anyhow, so I bought a penny bottle
+of ink, and with a quill-pen, and seven sheets of foolscap paper, I
+started off for Pope’s Court.
+
+“Well, to my surprise and delight, everything was as right as possible.
+The table was set out ready for me, and Mr. Duncan Ross was there to
+see that I got fairly to work. He started me off upon the letter A, and
+then he left me; but he would drop in from time to time to see that all
+was right with me. At two o’clock he bade me good-day, complimented me
+upon the amount that I had written, and locked the door of the office
+after me.
+
+“This went on day after day, Mr. Holmes, and on Saturday the manager
+came in and planked down four golden sovereigns for my week’s work.
+It was the same next week, and the same the week after. Every morning
+I was there at ten, and every afternoon I left at two. By degrees Mr.
+Duncan Ross took to coming in only once of a morning, and then, after
+a time, he did not come in at all. Still, of course, I never dared to
+leave the room for an instant, for I was not sure when he might come,
+and the billet was such a good one, and suited me so well, that I would
+not risk the loss of it.
+
+“Eight weeks passed away like this, and I had written about Abbots and
+Archery and Armor and Architecture and Attica, and hoped with diligence
+that I might get on to the B’s before very long. It cost me something
+in foolscap, and I had pretty nearly filled a shelf with my writings.
+And then suddenly the whole business came to an end.”
+
+“To an end?”
+
+“Yes, sir. And no later than this morning. I went to my work as usual
+at ten o’clock, but the door was shut and locked, with a little square
+of card-board hammered on to the middle of the panel with a tack. Here
+it is, and you can read for yourself.”
+
+He held up a piece of white card-board about the size of a sheet of
+note-paper. It read in this fashion:
+
+  “THE RED-HEADED LEAGUE
+   IS
+   DISSOLVED.
+   _October 9, 1890._”
+
+Sherlock Holmes and I surveyed this curt announcement and the rueful
+face behind it, until the comical side of the affair so completely
+overtopped every other consideration that we both burst out into a roar
+of laughter.
+
+“I cannot see that there is anything very funny,” cried our client,
+flushing up to the roots of his flaming head. “If you can do nothing
+better than laugh at me, I can go elsewhere.”
+
+“No, no,” cried Holmes, shoving him back into the chair from which he
+had half risen. “I really wouldn’t miss your case for the world. It is
+most refreshingly unusual. But there is, if you will excuse my saying
+so, something just a little funny about it. Pray what steps did you
+take when you found the card upon the door?”
+
+“I was staggered, sir. I did not know what to do. Then I called at
+the offices round, but none of them seemed to know anything about it.
+Finally, I went to the landlord, who is an accountant living on the
+ground-floor, and I asked him if he could tell me what had become of
+the Red-headed League. He said that he had never heard of any such
+body. Then I asked him who Mr. Duncan Ross was. He answered that the
+name was new to him.
+
+[Illustration: “THE DOOR WAS SHUT AND LOCKED”]
+
+“‘Well,’ said I, ‘the gentleman at No. 4.’
+
+“‘What, the red-headed man?’
+
+“‘Yes.’
+
+“‘Oh,’ said he, ‘his name was William Morris. He was a solicitor, and
+was using my room as a temporary convenience until his new premises
+were ready. He moved out yesterday.’
+
+“‘Where could I find him?’
+
+“‘Oh, at his new offices. He did tell me the address. Yes, 17 King
+Edward Street, near St. Paul’s.’
+
+“I started off, Mr. Holmes, but when I got to that address it was a
+manufactory of artificial knee-caps, and no one in it had ever heard of
+either Mr. William Morris or Mr. Duncan Ross.”
+
+“And what did you do then?” asked Holmes.
+
+“I went home to Saxe-Coburg Square, and I took the advice of my
+assistant. But he could not help me in any way. He could only say that
+if I waited I should hear by post. But that was not quite good enough,
+Mr. Holmes. I did not wish to lose such a place without a struggle, so,
+as I had heard that you were good enough to give advice to poor folk
+who were in need of it, I came right away to you.”
+
+“And you did very wisely,” said Holmes. “Your case is an exceedingly
+remarkable one, and I shall be happy to look into it. From what you
+have told me I think that it is possible that graver issues hang from
+it than might at first sight appear.”
+
+“Grave enough!” said Mr. Jabez Wilson. “Why, I have lost four pound a
+week.”
+
+“As far as you are personally concerned,” remarked Holmes, “I do not
+see that you have any grievance against this extraordinary league. On
+the contrary, you are, as I understand, richer by some £30, to say
+nothing of the minute knowledge which you have gained on every subject
+which comes under the letter A. You have lost nothing by them.”
+
+“No, sir. But I want to find out about them, and who they are, and what
+their object was in playing this prank—if it was a prank—upon me. It
+was a pretty expensive joke for them, for it cost them two and thirty
+pounds.”
+
+“We shall endeavor to clear up these points for you. And, first, one
+or two questions, Mr. Wilson. This assistant of yours who first called
+your attention to the advertisement—how long had he been with you?”
+
+“About a month then.”
+
+“How did he come?”
+
+“In answer to an advertisement.”
+
+“Was he the only applicant?”
+
+“No, I had a dozen.”
+
+“Why did you pick him?”
+
+“Because he was handy, and would come cheap.”
+
+“At half-wages, in fact.”
+
+“Yes.”
+
+“What is he like, this Vincent Spaulding?”
+
+“Small, stout-built, very quick in his ways, no hair on his face,
+though he’s not short of thirty. Has a white splash of acid upon his
+forehead.”
+
+Holmes sat up in his chair in considerable excitement. “I thought as
+much,” said he. “Have you ever observed that his ears are pierced for
+earrings?”
+
+“Yes, sir. He told me that a gypsy had done it for him when he was a
+lad.”
+
+“Hum!” said Holmes, sinking back in deep thought. “He is still with
+you?”
+
+“Oh yes, sir; I have only just left him.”
+
+“And has your business been attended to in your absence?”
+
+“Nothing to complain of, sir. There’s never very much to do of a
+morning.”
+
+“That will do, Mr. Wilson. I shall be happy to give you an opinion upon
+the subject in the course of a day or two. To-day is Saturday, and I
+hope that by Monday we may come to a conclusion.”
+
+“Well, Watson,” said Holmes, when our visitor had left us, “what do you
+make of it all?”
+
+“I make nothing of it,” I answered, frankly. “It is a most mysterious
+business.”
+
+“As a rule,” said Holmes, “the more bizarre a thing is the less
+mysterious it proves to be. It is your commonplace, featureless crimes
+which are really puzzling, just as a commonplace face is the most
+difficult to identify. But I must be prompt over this matter.”
+
+“What are you going to do, then?” I asked.
+
+“To smoke,” he answered. “It is quite a three-pipe problem, and I beg
+that you won’t speak to me for fifty minutes.” He curled himself up
+in his chair, with his thin knees drawn up to his hawk-like nose, and
+there he sat with his eyes closed and his black clay pipe thrusting out
+like the bill of some strange bird. I had come to the conclusion that
+he had dropped asleep, and indeed was nodding myself, when he suddenly
+sprang out of his chair with the gesture of a man who has made up his
+mind, and put his pipe down upon the mantel-piece.
+
+“Sarasate plays at the St. James’s Hall this afternoon,” he remarked.
+“What do you think, Watson? Could your patients spare you for a few
+hours?”
+
+“I have nothing to do to-day. My practice is never very absorbing.”
+
+“Then put on your hat and come. I am going through the city first, and
+we can have some lunch on the way. I observe that there is a good deal
+of German music on the programme, which is rather more to my taste than
+Italian or French. It is introspective, and I want to introspect. Come
+along!”
+
+We travelled by the Underground as far as Aldersgate; and a short walk
+took us to Saxe-Coburg Square, the scene of the singular story which we
+had listened to in the morning. It was a pokey, little, shabby-genteel
+place, where four lines of dingy two-storied brick houses looked out
+into a small railed-in enclosure, where a lawn of weedy grass and
+a few clumps of faded laurel-bushes made a hard fight against a
+smoke-laden and uncongenial atmosphere. Three gilt balls and a brown
+board with “JABEZ WILSON” in white letters, upon a corner
+house, announced the place where our red-headed client carried on his
+business. Sherlock Holmes stopped in front of it with his head on one
+side, and looked it all over, with his eyes shining brightly between
+puckered lids. Then he walked slowly up the street, and then down again
+to the corner, still looking keenly at the houses. Finally he returned
+to the pawnbroker’s, and, having thumped vigorously upon the pavement
+with his stick two or three times, he went up to the door and knocked.
+It was instantly opened by a bright-looking, clean-shaven young fellow,
+who asked him to step in.
+
+“Thank you,” said Holmes, “I only wished to ask you how you would go
+from here to the Strand.”
+
+“Third right, fourth left,” answered the assistant, promptly, closing
+the door.
+
+“Smart fellow, that,” observed Holmes, as we walked away. “He is, in my
+judgment, the fourth smartest man in London, and for daring I am not
+sure that he has not a claim to be third. I have known something of him
+before.”
+
+“Evidently,” said I, “Mr. Wilson’s assistant counts for a good deal in
+this mystery of the Red-headed League. I am sure that you inquired your
+way merely in order that you might see him.”
+
+“Not him.”
+
+“What then?”
+
+“The knees of his trousers.”
+
+“And what did you see?”
+
+“What I expected to see.”
+
+“Why did you beat the pavement?”
+
+“My dear doctor, this is a time for observation, not for talk. We are
+spies in an enemy’s country. We know something of Saxe-Coburg Square.
+Let us now explore the parts which lie behind it.”
+
+The road in which we found ourselves as we turned round the corner
+from the retired Saxe-Coburg Square presented as great a contrast to
+it as the front of a picture does to the back. It was one of the main
+arteries which convey the traffic of the city to the north and west.
+The roadway was blocked with the immense stream of commerce flowing
+in a double tide inward and outward, while the foot-paths were black
+with the hurrying swarm of pedestrians. It was difficult to realize
+as we looked at the line of fine shops and stately business premises
+that they really abutted on the other side upon the faded and stagnant
+square which we had just quitted.
+
+“Let me see,” said Holmes, standing at the corner, and glancing along
+the line, “I should like just to remember the order of the houses here.
+It is a hobby of mine to have an exact knowledge of London. There is
+Mortimer’s, the tobacconist, the little newspaper shop, the Coburg
+branch of the City and Suburban Bank, the Vegetarian Restaurant, and
+McFarlane’s carriage-building depot. That carries us right on to the
+other block. And now, doctor, we’ve done our work, so it’s time we had
+some play. A sandwich and a cup of coffee, and then off to violin-land,
+where all is sweetness and delicacy and harmony, and there are no
+red-headed clients to vex us with their conundrums.”
+
+My friend was an enthusiastic musician, being himself not only a
+very capable performer, but a composer of no ordinary merit. All the
+afternoon he sat in the stalls wrapped in the most perfect happiness,
+gently waving his long, thin fingers in time to the music, while his
+gently smiling face and his languid, dreamy eyes were as unlike those
+of Holmes, the sleuth-hound, Holmes the relentless, keen-witted,
+ready-handed criminal agent, as it was possible to conceive. In his
+singular character the dual nature alternately asserted itself, and
+his extreme exactness and astuteness represented, as I have often
+thought, the reaction against the poetic and contemplative mood which
+occasionally predominated in him. The swing of his nature took him from
+extreme languor to devouring energy; and, as I knew well, he was never
+so truly formidable as when, for days on end, he had been lounging in
+his arm-chair amid his improvisations and his black-letter editions.
+Then it was that the lust of the chase would suddenly come upon him,
+and that his brilliant reasoning power would rise to the level of
+intuition, until those who were unacquainted with his methods would
+look askance at him as on a man whose knowledge was not that of other
+mortals. When I saw him that afternoon so enrapt in the music at St.
+James’s Hall I felt that an evil time might be coming upon those whom
+he had set himself to hunt down.
+
+“You want to go home, no doubt, doctor,” he remarked, as we emerged.
+
+“Yes, it would be as well.”
+
+“And I have some business to do which will take some hours. This
+business at Coburg Square is serious.”
+
+“Why serious?”
+
+“A considerable crime is in contemplation. I have every reason to
+believe that we shall be in time to stop it. But to-day being Saturday
+rather complicates matters. I shall want your help to-night.”
+
+“At what time?”
+
+“Ten will be early enough.”
+
+“I shall be at Baker Street at ten.”
+
+“Very well. And, I say, doctor, there may be some little danger, so
+kindly put your army revolver in your pocket.” He waved his hand,
+turned on his heel, and disappeared in an instant among the crowd.
+
+[Illustration: “ALL AFTERNOON HE SAT IN THE STALLS”]
+
+I trust that I am not more dense than my neighbors, but I was always
+oppressed with a sense of my own stupidity in my dealings with Sherlock
+Holmes. Here I had heard what he had heard, I had seen what he had
+seen, and yet from his words it was evident that he saw clearly not
+only what had happened, but what was about to happen, while to me the
+whole business was still confused and grotesque. As I drove home to
+my house in Kensington I thought over it all, from the extraordinary
+story of the red-headed copier of the “Encyclopædia” down to the visit
+to Saxe-Coburg Square, and the ominous words with which he had parted
+from me. What was this nocturnal expedition, and why should I go armed?
+Where were we going, and what were we to do? I had the hint from Holmes
+that this smooth-faced pawnbroker’s assistant was a formidable man—a
+man who might play a deep game. I tried to puzzle it out, but gave it
+up in despair, and set the matter aside until night should bring an
+explanation.
+
+It was a quarter past nine when I started from home and made my way
+across the Park, and so through Oxford Street to Baker Street. Two
+hansoms were standing at the door, and, as I entered the passage, I
+heard the sound of voices from above. On entering his room I found
+Holmes in animated conversation with two men, one of whom I recognized
+as Peter Jones, the official police agent, while the other was a long,
+thin, sad-faced man, with a very shiny hat and oppressively respectable
+frock-coat.
+
+“Ha! our party is complete,” said Holmes, buttoning up his pea-jacket,
+and taking his heavy hunting crop from the rack. “Watson, I think
+you know Mr. Jones, of Scotland Yard? Let me introduce you to Mr.
+Merryweather, who is to be our companion in to-night’s adventure.”
+
+“We’re hunting in couples again, doctor, you see,” said Jones, in his
+consequential way. “Our friend here is a wonderful man for starting a
+chase. All he wants is an old dog to help him to do the running down.”
+
+“I hope a wild goose may not prove to be the end of our chase,”
+observed Mr. Merryweather, gloomily.
+
+“You may place considerable confidence in Mr. Holmes, sir,” said the
+police agent, loftily. “He has his own little methods, which are, if he
+won’t mind my saying so, just a little too theoretical and fantastic,
+but he has the makings of a detective in him. It is not too much to
+say that once or twice, as in that business of the Sholto murder and
+the Agra treasure, he has been more nearly correct than the official
+force.”
+
+“Oh, if you say so, Mr. Jones, it is all right,” said the stranger,
+with deference. “Still, I confess that I miss my rubber. It is the
+first Saturday night for seven-and-twenty years that I have not had my
+rubber.”
+
+“I think you will find,” said Sherlock Holmes, “that you will play for
+a higher stake to-night than you have ever done yet, and that the play
+will be more exciting. For you, Mr. Merryweather, the stake will be
+some £30,000; and for you, Jones, it will be the man upon whom you wish
+to lay your hands.”
+
+“John Clay, the murderer, thief, smasher, and forger. He’s a young man,
+Mr. Merryweather, but he is at the head of his profession, and I would
+rather have my bracelets on him than on any criminal in London. He’s a
+remarkable man, is young John Clay. His grandfather was a royal duke,
+and he himself has been to Eton and Oxford. His brain is as cunning as
+his fingers, and though we meet signs of him at every turn, we never
+know where to find the man himself. He’ll crack a crib in Scotland one
+week, and be raising money to build an orphanage in Cornwall the next.
+I’ve been on his track for years, and have never set eyes on him yet.”
+
+“I hope that I may have the pleasure of introducing you to-night. I’ve
+had one or two little turns also with Mr. John Clay, and I agree with
+you that he is at the head of his profession. It is past ten, however,
+and quite time that we started. If you two will take the first hansom,
+Watson and I will follow in the second.”
+
+Sherlock Holmes was not very communicative during the long drive,
+and lay back in the cab humming the tunes which he had heard in the
+afternoon. We rattled through an endless labyrinth of gas-lit streets
+until we emerged into Farringdon Street.
+
+“We are close there now,” my friend remarked. “This fellow Merryweather
+is a bank director, and personally interested in the matter. I thought
+it as well to have Jones with us also. He is not a bad fellow, though
+an absolute imbecile in his profession. He has one positive virtue. He
+is as brave as a bull-dog, and as tenacious as a lobster if he gets his
+claws upon any one. Here we are, and they are waiting for us.”
+
+We had reached the same crowded thoroughfare in which we had found
+ourselves in the morning. Our cabs were dismissed, and, following
+the guidance of Mr. Merryweather, we passed down a narrow passage
+and through a side door, which he opened for us. Within there was a
+small corridor, which ended in a very massive iron gate. This also was
+opened, and led down a flight of winding stone steps, which terminated
+at another formidable gate. Mr. Merryweather stopped to light a
+lantern, and then conducted us down a dark, earth-smelling passage, and
+so, after opening a third door, into a huge vault or cellar, which was
+piled all round with crates and massive boxes.
+
+“You are not very vulnerable from above,” Holmes remarked, as he held
+up the lantern and gazed about him.
+
+“Nor from below,” said Mr. Merryweather, striking his stick upon the
+flags which lined the floor. “Why, dear me, it sounds quite hollow!” he
+remarked, looking up in surprise.
+
+“I must really ask you to be a little more quiet,” said Holmes,
+severely. “You have already imperilled the whole success of our
+expedition. Might I beg that you would have the goodness to sit down
+upon one of those boxes, and not to interfere?”
+
+The solemn Mr. Merryweather perched himself upon a crate, with a very
+injured expression upon his face, while Holmes fell upon his knees
+upon the floor, and, with the lantern and a magnifying lens, began to
+examine minutely the cracks between the stones. A few seconds sufficed
+to satisfy him, for he sprang to his feet again, and put his glass in
+his pocket.
+
+“We have at least an hour before us,” he remarked; “for they can
+hardly take any steps until the good pawnbroker is safely in bed.
+Then they will not lose a minute, for the sooner they do their work
+the longer time they will have for their escape. We are at present,
+doctor—as no doubt you have divined—in the cellar of the city branch
+of one of the principal London banks. Mr. Merryweather is the chairman
+of directors, and he will explain to you that there are reasons why the
+more daring criminals of London should take a considerable interest in
+this cellar at present.”
+
+“It is our French gold,” whispered the director. “We have had several
+warnings that an attempt might be made upon it.”
+
+“Your French gold?”
+
+“Yes. We had occasion some months ago to strengthen our resources, and
+borrowed, for that purpose, 30,000 napoleons from the Bank of France.
+It has become known that we have never had occasion to unpack the
+money, and that it is still lying in our cellar. The crate upon which
+I sit contains 2000 napoleons packed between layers of lead foil. Our
+reserve of bullion is much larger at present than is usually kept in a
+single branch office, and the directors have had misgivings upon the
+subject.”
+
+“Which were very well justified,” observed Holmes. “And now it is time
+that we arranged our little plans. I expect that within an hour matters
+will come to a head. In the mean time, Mr. Merryweather, we must put
+the screen over that dark lantern.”
+
+“And sit in the dark?”
+
+“I am afraid so. I had brought a pack of cards in my pocket, and I
+thought that, as we were a _partie carrée_, you might have your rubber
+after all. But I see that the enemy’s preparations have gone so far
+that we cannot risk the presence of a light. And, first of all, we must
+choose our positions. These are daring men, and though we shall take
+them at a disadvantage, they may do us some harm unless we are careful.
+I shall stand behind this crate, and do you conceal yourselves behind
+those. Then, when I flash a light upon them, close in swiftly. If they
+fire, Watson, have no compunction about shooting them down.”
+
+I placed my revolver, cocked, upon the top of the wooden case behind
+which I crouched. Holmes shot the slide across the front of his
+lantern, and left us in pitch darkness—such an absolute darkness
+as I have never before experienced. The smell of hot metal remained
+to assure us that the light was still there, ready to flash out at
+a moment’s notice. To me, with my nerves worked up to a pitch of
+expectancy, there was something depressing and subduing in the sudden
+gloom, and in the cold, dank air of the vault.
+
+“They have but one retreat,” whispered Holmes. “That is back through
+the house into Saxe-Coburg Square. I hope that you have done what I
+asked you, Jones?”
+
+“I have an inspector and two officers waiting at the front door.”
+
+“Then we have stopped all the holes. And now we must be silent and
+wait.”
+
+What a time it seemed! From comparing notes afterwards it was but an
+hour and a quarter, yet it appeared to me that the night must have
+almost gone, and the dawn be breaking above us. My limbs were weary and
+stiff, for I feared to change my position; yet my nerves were worked
+up to the highest pitch of tension, and my hearing was so acute that I
+could not only hear the gentle breathing of my companions, but I could
+distinguish the deeper, heavier in-breath of the bulky Jones from the
+thin, sighing note of the bank director. From my position I could look
+over the case in the direction of the floor. Suddenly my eyes caught
+the glint of a light.
+
+At first it was but a lurid spark upon the stone pavement. Then it
+lengthened out until it became a yellow line, and then, without any
+warning or sound, a gash seemed to open and a hand appeared; a white,
+almost womanly hand, which felt about in the centre of the little area
+of light. For a minute or more the hand, with its writhing fingers,
+protruded out of the floor. Then it was withdrawn as suddenly as it
+appeared, and all was dark again save the single lurid spark which
+marked a chink between the stones.
+
+Its disappearance, however, was but momentary. With a rending, tearing
+sound, one of the broad, white stones turned over upon its side, and
+left a square, gaping hole, through which streamed the light of a
+lantern. Over the edge there peeped a clean-cut, boyish face, which
+looked keenly about it, and then, with a hand on either side of the
+aperture, drew itself shoulder-high and waist-high, until one knee
+rested upon the edge. In another instant he stood at the side of the
+hole, and was hauling after him a companion, lithe and small like
+himself, with a pale face and a shock of very red hair.
+
+“It’s all clear,” he whispered. “Have you the chisel and the bags.
+Great Scott! Jump, Archie, jump, and I’ll swing for it!”
+
+Sherlock Holmes had sprung out and seized the intruder by the collar.
+The other dived down the hole, and I heard the sound of rending cloth
+as Jones clutched at his skirts. The light flashed upon the barrel of a
+revolver, but Holmes’s hunting crop came down on the man’s wrist, and
+the pistol clinked upon the stone floor.
+
+“It’s no use, John Clay,” said Holmes, blandly. “You have no chance at
+all.”
+
+“So I see,” the other answered, with the utmost coolness. “I fancy that
+my pal is all right, though I see you have got his coat-tails.”
+
+“There are three men waiting for him at the door,” said Holmes.
+
+“Oh, indeed! You seem to have done the thing very completely. I must
+compliment you.”
+
+“And I you,” Holmes answered. “Your red-headed idea was very new and
+effective.”
+
+“You’ll see your pal again presently,” said Jones. “He’s quicker at
+climbing down holes than I am. Just hold out while I fix the derbies.”
+
+“I beg that you will not touch me with your filthy hands,” remarked
+our prisoner, as the handcuffs clattered upon his wrists. “You may not
+be aware that I have royal blood in my veins. Have the goodness, also,
+when you address me always to say ‘sir’ and ‘please.’”
+
+“All right,” said Jones, with a stare and a snigger. “Well, would you
+please, sir, march up-stairs, where we can get a cab to carry your
+highness to the police-station?”
+
+“That is better,” said John Clay, serenely. He made a sweeping bow to
+the three of us, and walked quietly off in the custody of the detective.
+
+“Really Mr. Holmes,” said Mr. Merryweather, as we followed them from
+the cellar, “I do not know how the bank can thank you or repay you.
+There is no doubt that you have detected and defeated in the most
+complete manner one of the most determined attempts at bank robbery
+that have ever come within my experience.”
+
+“I have had one or two little scores of my own to settle with Mr.
+John Clay,” said Holmes. “I have been at some small expense over this
+matter, which I shall expect the bank to refund, but beyond that I am
+amply repaid by having had an experience which is in many ways unique,
+and by hearing the very remarkable narrative of the Red-headed League.”
+
+       *       *       *       *       *
+
+“You see, Watson,” he explained, in the early hours of the morning,
+as we sat over a glass of whiskey-and-soda in Baker Street, “it was
+perfectly obvious from the first that the only possible object of this
+rather fantastic business of the advertisement of the League, and the
+copying of the ‘Encyclopædia,’ must be to get this not over-bright
+pawnbroker out of the way for a number of hours every day. It was a
+curious way of managing it, but, really, it would be difficult to
+suggest a better. The method was no doubt suggested to Clay’s ingenious
+mind by the color of his accomplice’s hair. The £4 a week was a lure
+which must draw him, and what was it to them, who were playing for
+thousands? They put in the advertisement, one rogue has the temporary
+office, the other rogue incites the man to apply for it, and together
+they manage to secure his absence every morning in the week. From
+the time that I heard of the assistant having come for half wages,
+it was obvious to me that he had some strong motive for securing the
+situation.”
+
+“But how could you guess what the motive was?”
+
+“Had there been women in the house, I should have suspected a mere
+vulgar intrigue. That, however, was out of the question. The man’s
+business was a small one, and there was nothing in his house which
+could account for such elaborate preparations, and such an expenditure
+as they were at. It must, then, be something out of the house. What
+could it be? I thought of the assistant’s fondness for photography,
+and his trick of vanishing into the cellar. The cellar! There was the
+end of this tangled clue. Then I made inquiries as to this mysterious
+assistant, and found that I had to deal with one of the coolest
+and most daring criminals in London. He was doing something in the
+cellar—something which took many hours a day for months on end. What
+could it be, once more? I could think of nothing save that he was
+running a tunnel to some other building.
+
+“So far I had got when we went to visit the scene of action. I
+surprised you by beating upon the pavement with my stick. I was
+ascertaining whether the cellar stretched out in front or behind.
+It was not in front. Then I rang the bell, and, as I hoped, the
+assistant answered it. We have had some skirmishes, but we had never
+set eyes upon each other before. I hardly looked at his face. His
+knees were what I wished to see. You must yourself have remarked how
+worn, wrinkled, and stained they were. They spoke of those hours of
+burrowing. The only remaining point was what they were burrowing for. I
+walked round the corner, saw that the City and Suburban Bank abutted on
+our friend’s premises, and felt that I had solved my problem. When you
+drove home after the concert I called upon Scotland Yard, and upon the
+chairman of the bank directors, with the result that you have seen.”
+
+“And how could you tell that they would make their attempt to-night?” I
+asked.
+
+“Well, when they closed their League offices that was a sign that they
+cared no longer about Mr. Jabez Wilson’s presence—in other words,
+that they had completed their tunnel. But it was essential that they
+should use it soon, as it might be discovered, or the bullion might
+be removed. Saturday would suit them better than any other day, as it
+would give them two days for their escape. For all these reasons I
+expected them to come to-night.”
+
+“You reasoned it out beautifully,” I exclaimed, in unfeigned
+admiration. “It is so long a chain, and yet every link rings true.”
+
+“It saved me from ennui,” he answered, yawning. “Alas! I already feel
+it closing in upon me. My life is spent in one long effort to escape
+from the commonplaces of existence. These little problems help me to do
+so.”
+
+“And you are a benefactor of the race,” said I.
+
+He shrugged his shoulders. “Well, perhaps, after all, it is of some
+little use,” he remarked. “‘L’homme c’est rien—l’oeuvre c’est
+tout,’ as Gustave Flaubert wrote to Georges Sand.”

--- a/examples/md/markdowntest1.md
+++ b/examples/md/markdowntest1.md
@@ -1,0 +1,68 @@
+# h1 Heading 8-)
+## h2 Heading
+### h3 Heading
+
+
+## Typographic replacements
+
+Enable typographer option to see result.
+(c) (C) (r) (R) (tm) (TM) (p) (P) +-
+"Smartypants, double quotes" and 'single quotes'
+
+## Emphasis
+
+**This is bold text**
+
+__This is bold text__
+
+*This is italic text*
+
+_This is italic text_
+
+~~Strikethrough~~
+
++ Create a list by starting a line with `+`, `-`, or `*`
++ Sub-lists are made by indenting 2 spaces:
+  - Marker character change forces new list start:
+    * Ac tristique libero volutpat at
+    + Facilisis in pretium nisl aliquet
+    - Nulla volutpat aliquam velit
++ Very easy!
+
+Block code "fences"
+
+```
+Sample text here...
+```
+
+## Tables
+
+| Option | Description |
+| ------ | ----------- |
+| data   | path to data files to supply the data that will be passed into templates. |
+| engine | engine to be used for processing templates. Handlebars is the default. |
+| ext    | extension to be used for dest files. |
+
+## Links
+
+[link text](http://dev.nodeca.com)
+
+[link with title](http://nodeca.github.io/pica/demo/ "title text!")
+
+Autoconverted link https://github.com/nodeca/pica (enable linkify to see)
+
+## Images
+
+![Minion](https://octodex.github.com/images/minion.png)
+![Stormtroopocat](https://octodex.github.com/images/stormtroopocat.jpg "The Stormtroopocat")
+
+Like links, Images also have a footnote style syntax
+
+![Alt text][id]
+
+With a reference later in the document defining the URL location:
+
+[id]: https://octodex.github.com/images/dojocat.jpg  "The Dojocat"
+
+
+Credits: https://markdown-it.github.io/

--- a/examples/md/markdowntest1.md
+++ b/examples/md/markdowntest1.md
@@ -1,4 +1,4 @@
-# h1 Heading 8-)
+# h1 Heading
 ## h2 Heading
 ### h3 Heading
 
@@ -11,37 +11,22 @@ Enable typographer option to see result.
 
 ## Emphasis
 
+
+some text before **This is bold text** some text after
 **This is bold text**
 
+some text before __This is bold text__ some text after
 __This is bold text__
 
-*This is italic text*
 
-_This is italic text_
+some text before   *This is italic text*
 
-~~Strikethrough~~
-
-+ Create a list by starting a line with `+`, `-`, or `*`
-+ Sub-lists are made by indenting 2 spaces:
-  - Marker character change forces new list start:
-    * Ac tristique libero volutpat at
-    + Facilisis in pretium nisl aliquet
-    - Nulla volutpat aliquam velit
-+ Very easy!
+_This is italic text_ some text after
 
 Block code "fences"
-
 ```
 Sample text here...
 ```
-
-## Tables
-
-| Option | Description |
-| ------ | ----------- |
-| data   | path to data files to supply the data that will be passed into templates. |
-| engine | engine to be used for processing templates. Handlebars is the default. |
-| ext    | extension to be used for dest files. |
 
 ## Links
 
@@ -51,10 +36,6 @@ Sample text here...
 
 Autoconverted link https://github.com/nodeca/pica (enable linkify to see)
 
-## Images
-
-![Minion](https://octodex.github.com/images/minion.png)
-![Stormtroopocat](https://octodex.github.com/images/stormtroopocat.jpg "The Stormtroopocat")
 
 Like links, Images also have a footnote style syntax
 

--- a/examples/test/The Adventure of the Six Napoleans.txt
+++ b/examples/test/The Adventure of the Six Napoleans.txt
@@ -1,0 +1,936 @@
+THE ADVENTURE OF THE SIX NAPOLEONS
+
+
+It was no very unusual thing for Mr. Lestrade, of Scotland Yard,
+to look in upon us of an evening, and his visits were welcome to
+Sherlock Holmes, for they enabled him to keep in touch with all
+that was going on at the police headquarters. In return for the
+news which Lestrade would bring, Holmes was always ready to
+listen with attention to the details of any case upon which the
+detective was engaged, and was able occasionally, without any
+active interference, to give some hint or suggestion drawn from
+his own vast knowledge and experience.
+
+On this particular evening, Lestrade had spoken of the weather
+and the newspapers. Then he had fallen silent, puffing
+thoughtfully at his cigar. Holmes looked keenly at him.
+
+“Anything remarkable on hand?” he asked.
+
+“Oh, no, Mr. Holmes—nothing very particular.”
+
+“Then tell me about it.”
+
+Lestrade laughed.
+
+“Well, Mr. Holmes, there is no use denying that there _is_
+something on my mind. And yet it is such an absurd business, that
+I hesitated to bother you about it. On the other hand, although
+it is trivial, it is undoubtedly queer, and I know that you have
+a taste for all that is out of the common. But, in my opinion, it
+comes more in Dr. Watson’s line than ours.”
+
+“Disease?” said I.
+
+“Madness, anyhow. And a queer madness, too. You wouldn’t think
+there was anyone living at this time of day who had such a hatred
+of Napoleon the First that he would break any image of him that
+he could see.”
+
+Holmes sank back in his chair.
+
+“That’s no business of mine,” said he.
+
+“Exactly. That’s what I said. But then, when the man commits
+burglary in order to break images which are not his own, that
+brings it away from the doctor and on to the policeman.”
+
+Holmes sat up again.
+
+“Burglary! This is more interesting. Let me hear the details.”
+
+Lestrade took out his official notebook and refreshed his memory
+from its pages.
+
+“The first case reported was four days ago,” said he. “It was at
+the shop of Morse Hudson, who has a place for the sale of
+pictures and statues in the Kennington Road. The assistant had
+left the front shop for an instant, when he heard a crash, and
+hurrying in he found a plaster bust of Napoleon, which stood with
+several other works of art upon the counter, lying shivered into
+fragments. He rushed out into the road, but, although several
+passers-by declared that they had noticed a man run out of the
+shop, he could neither see anyone nor could he find any means of
+identifying the rascal. It seemed to be one of those senseless
+acts of hooliganism which occur from time to time, and it was
+reported to the constable on the beat as such. The plaster cast
+was not worth more than a few shillings, and the whole affair
+appeared to be too childish for any particular investigation.
+
+“The second case, however, was more serious, and also more
+singular. It occurred only last night.
+
+“In Kennington Road, and within a few hundred yards of Morse
+Hudson’s shop, there lives a well-known medical practitioner,
+named Dr. Barnicot, who has one of the largest practices upon the
+south side of the Thames. His residence and principal
+consulting-room is at Kennington Road, but he has a branch
+surgery and dispensary at Lower Brixton Road, two miles away.
+This Dr. Barnicot is an enthusiastic admirer of Napoleon, and his
+house is full of books, pictures, and relics of the French
+Emperor. Some little time ago he purchased from Morse Hudson two
+duplicate plaster casts of the famous head of Napoleon by the
+French sculptor, Devine. One of these he placed in his hall in
+the house at Kennington Road, and the other on the mantelpiece of
+the surgery at Lower Brixton. Well, when Dr. Barnicot came down
+this morning he was astonished to find that his house had been
+burgled during the night, but that nothing had been taken save
+the plaster head from the hall. It had been carried out and had
+been dashed savagely against the garden wall, under which its
+splintered fragments were discovered.”
+
+Holmes rubbed his hands.
+
+“This is certainly very novel,” said he.
+
+“I thought it would please you. But I have not got to the end
+yet. Dr. Barnicot was due at his surgery at twelve o’clock, and
+you can imagine his amazement when, on arriving there, he found
+that the window had been opened in the night and that the broken
+pieces of his second bust were strewn all over the room. It had
+been smashed to atoms where it stood. In neither case were there
+any signs which could give us a clue as to the criminal or
+lunatic who had done the mischief. Now, Mr. Holmes, you have got
+the facts.”
+
+“They are singular, not to say grotesque,” said Holmes. “May I
+ask whether the two busts smashed in Dr. Barnicot’s rooms were
+the exact duplicates of the one which was destroyed in Morse
+Hudson’s shop?”
+
+“They were taken from the same mould.”
+
+“Such a fact must tell against the theory that the man who breaks
+them is influenced by any general hatred of Napoleon. Considering
+how many hundreds of statues of the great Emperor must exist in
+London, it is too much to suppose such a coincidence as that a
+promiscuous iconoclast should chance to begin upon three
+specimens of the same bust.”
+
+“Well, I thought as you do,” said Lestrade. “On the other hand,
+this Morse Hudson is the purveyor of busts in that part of
+London, and these three were the only ones which had been in his
+shop for years. So, although, as you say, there are many hundreds
+of statues in London, it is very probable that these three were
+the only ones in that district. Therefore, a local fanatic would
+begin with them. What do you think, Dr. Watson?”
+
+“There are no limits to the possibilities of monomania,” I
+answered. “There is the condition which the modern French
+psychologists have called the _idée fixe_, which may be trifling
+in character, and accompanied by complete sanity in every other
+way. A man who had read deeply about Napoleon, or who had
+possibly received some hereditary family injury through the great
+war, might conceivably form such an _idée fixe_ and under its
+influence be capable of any fantastic outrage.”
+
+“That won’t do, my dear Watson,” said Holmes, shaking his head,
+“for no amount of _idée fixe_ would enable your interesting
+monomaniac to find out where these busts were situated.”
+
+“Well, how do _you_ explain it?”
+
+“I don’t attempt to do so. I would only observe that there is a
+certain method in the gentleman’s eccentric proceedings. For
+example, in Dr. Barnicot’s hall, where a sound might arouse the
+family, the bust was taken outside before being broken, whereas
+in the surgery, where there was less danger of an alarm, it was
+smashed where it stood. The affair seems absurdly trifling, and
+yet I dare call nothing trivial when I reflect that some of my
+most classic cases have had the least promising commencement. You
+will remember, Watson, how the dreadful business of the Abernetty
+family was first brought to my notice by the depth which the
+parsley had sunk into the butter upon a hot day. I can’t afford,
+therefore, to smile at your three broken busts, Lestrade, and I
+shall be very much obliged to you if you will let me hear of any
+fresh development of so singular a chain of events.”
+
+The development for which my friend had asked came in a quicker
+and an infinitely more tragic form than he could have imagined. I
+was still dressing in my bedroom next morning, when there was a
+tap at the door and Holmes entered, a telegram in his hand. He
+read it aloud:
+
+“Come instantly, 131, Pitt Street, Kensington.—LESTRADE.”
+
+“What is it, then?” I asked.
+
+“Don’t know—may be anything. But I suspect it is the sequel of
+the story of the statues. In that case our friend the
+image-breaker has begun operations in another quarter of London.
+There’s coffee on the table, Watson, and I have a cab at the
+door.”
+
+In half an hour we had reached Pitt Street, a quiet little
+backwater just beside one of the briskest currents of London
+life. No. 131 was one of a row, all flat-chested, respectable,
+and most unromantic dwellings. As we drove up, we found the
+railings in front of the house lined by a curious crowd. Holmes
+whistled.
+
+“By George! It’s attempted murder at the least. Nothing less will
+hold the London message-boy. There’s a deed of violence indicated
+in that fellow’s round shoulders and outstretched neck. What’s
+this, Watson? The top steps swilled down and the other ones dry.
+Footsteps enough, anyhow! Well, well, there’s Lestrade at the
+front window, and we shall soon know all about it.”
+
+The official received us with a very grave face and showed us
+into a sitting-room, where an exceedingly unkempt and agitated
+elderly man, clad in a flannel dressing-gown, was pacing up and
+down. He was introduced to us as the owner of the house—Mr.
+Horace Harker, of the Central Press Syndicate.
+
+“It’s the Napoleon bust business again,” said Lestrade. “You
+seemed interested last night, Mr. Holmes, so I thought perhaps
+you would be glad to be present now that the affair has taken a
+very much graver turn.”
+
+“What has it turned to, then?”
+
+“To murder. Mr. Harker, will you tell these gentlemen exactly
+what has occurred?”
+
+The man in the dressing-gown turned upon us with a most
+melancholy face.
+
+“It’s an extraordinary thing,” said he, “that all my life I have
+been collecting other people’s news, and now that a real piece of
+news has come my own way I am so confused and bothered that I
+can’t put two words together. If I had come in here as a
+journalist, I should have interviewed myself and had two columns
+in every evening paper. As it is, I am giving away valuable copy
+by telling my story over and over to a string of different
+people, and I can make no use of it myself. However, I’ve heard
+your name, Mr. Sherlock Holmes, and if you’ll only explain this
+queer business, I shall be paid for my trouble in telling you the
+story.”
+
+Holmes sat down and listened.
+
+“It all seems to centre round that bust of Napoleon which I
+bought for this very room about four months ago. I picked it up
+cheap from Harding Brothers, two doors from the High Street
+Station. A great deal of my journalistic work is done at night,
+and I often write until the early morning. So it was to-day. I
+was sitting in my den, which is at the back of the top of the
+house, about three o’clock, when I was convinced that I heard
+some sounds downstairs. I listened, but they were not repeated,
+and I concluded that they came from outside. Then suddenly, about
+five minutes later, there came a most horrible yell—the most
+dreadful sound, Mr. Holmes, that ever I heard. It will ring in my
+ears as long as I live. I sat frozen with horror for a minute or
+two. Then I seized the poker and went downstairs. When I entered
+this room I found the window wide open, and I at once observed
+that the bust was gone from the mantelpiece. Why any burglar
+should take such a thing passes my understanding, for it was only
+a plaster cast and of no real value whatever.
+
+“You can see for yourself that anyone going out through that open
+window could reach the front doorstep by taking a long stride.
+This was clearly what the burglar had done, so I went round and
+opened the door. Stepping out into the dark, I nearly fell over a
+dead man, who was lying there. I ran back for a light and there
+was the poor fellow, a great gash in his throat and the whole
+place swimming in blood. He lay on his back, his knees drawn up,
+and his mouth horribly open. I shall see him in my dreams. I had
+just time to blow on my police-whistle, and then I must have
+fainted, for I knew nothing more until I found the policeman
+standing over me in the hall.”
+
+“Well, who was the murdered man?” asked Holmes.
+
+“There’s nothing to show who he was,” said Lestrade. “You shall
+see the body at the mortuary, but we have made nothing of it up
+to now. He is a tall man, sunburned, very powerful, not more than
+thirty. He is poorly dressed, and yet does not appear to be a
+labourer. A horn-handled clasp knife was lying in a pool of blood
+beside him. Whether it was the weapon which did the deed, or
+whether it belonged to the dead man, I do not know. There was no
+name on his clothing, and nothing in his pockets save an apple,
+some string, a shilling map of London, and a photograph. Here it
+is.”
+
+It was evidently taken by a snapshot from a small camera. It
+represented an alert, sharp-featured simian man, with thick
+eyebrows and a very peculiar projection of the lower part of the
+face, like the muzzle of a baboon.
+
+“And what became of the bust?” asked Holmes, after a careful
+study of this picture.
+
+“We had news of it just before you came. It has been found in the
+front garden of an empty house in Campden House Road. It was
+broken into fragments. I am going round now to see it. Will you
+come?”
+
+“Certainly. I must just take one look round.” He examined the
+carpet and the window. “The fellow had either very long legs or
+was a most active man,” said he. “With an area beneath, it was no
+mean feat to reach that window ledge and open that window.
+Getting back was comparatively simple. Are you coming with us to
+see the remains of your bust, Mr. Harker?”
+
+The disconsolate journalist had seated himself at a
+writing-table.
+
+“I must try and make something of it,” said he, “though I have no
+doubt that the first editions of the evening papers are out
+already with full details. It’s like my luck! You remember when
+the stand fell at Doncaster? Well, I was the only journalist in
+the stand, and my journal the only one that had no account of it,
+for I was too shaken to write it. And now I’ll be too late with a
+murder done on my own doorstep.”
+
+As we left the room, we heard his pen travelling shrilly over the
+foolscap.
+
+The spot where the fragments of the bust had been found was only
+a few hundred yards away. For the first time our eyes rested upon
+this presentment of the great emperor, which seemed to raise such
+frantic and destructive hatred in the mind of the unknown. It lay
+scattered, in splintered shards, upon the grass. Holmes picked up
+several of them and examined them carefully. I was convinced,
+from his intent face and his purposeful manner, that at last he
+was upon a clue.
+
+“Well?” asked Lestrade.
+
+Holmes shrugged his shoulders.
+
+“We have a long way to go yet,” said he. “And yet—and yet—well,
+we have some suggestive facts to act upon. The possession of this
+trifling bust was worth more, in the eyes of this strange
+criminal, than a human life. That is one point. Then there is the
+singular fact that he did not break it in the house, or
+immediately outside the house, if to break it was his sole
+object.”
+
+“He was rattled and bustled by meeting this other fellow. He
+hardly knew what he was doing.”
+
+“Well, that’s likely enough. But I wish to call your attention
+very particularly to the position of this house, in the garden of
+which the bust was destroyed.”
+
+Lestrade looked about him.
+
+“It was an empty house, and so he knew that he would not be
+disturbed in the garden.”
+
+“Yes, but there is another empty house farther up the street
+which he must have passed before he came to this one. Why did he
+not break it there, since it is evident that every yard that he
+carried it increased the risk of someone meeting him?”
+
+“I give it up,” said Lestrade.
+
+Holmes pointed to the street lamp above our heads.
+
+“He could see what he was doing here, and he could not there.
+That was his reason.”
+
+“By Jove! that’s true,” said the detective. “Now that I come to
+think of it, Dr. Barnicot’s bust was broken not far from his red
+lamp. Well, Mr. Holmes, what are we to do with that fact?”
+
+“To remember it—to docket it. We may come on something later
+which will bear upon it. What steps do you propose to take now,
+Lestrade?”
+
+“The most practical way of getting at it, in my opinion, is to
+identify the dead man. There should be no difficulty about that.
+When we have found who he is and who his associates are, we
+should have a good start in learning what he was doing in Pitt
+Street last night, and who it was who met him and killed him on
+the doorstep of Mr. Horace Harker. Don’t you think so?”
+
+“No doubt; and yet it is not quite the way in which I should
+approach the case.”
+
+“What would you do then?”
+
+“Oh, you must not let me influence you in any way. I suggest that
+you go on your line and I on mine. We can compare notes
+afterwards, and each will supplement the other.”
+
+“Very good,” said Lestrade.
+
+“If you are going back to Pitt Street, you might see Mr. Horace
+Harker. Tell him for me that I have quite made up my mind, and
+that it is certain that a dangerous homicidal lunatic, with
+Napoleonic delusions, was in his house last night. It will be
+useful for his article.”
+
+Lestrade stared.
+
+“You don’t seriously believe that?”
+
+Holmes smiled.
+
+“Don’t I? Well, perhaps I don’t. But I am sure that it will
+interest Mr. Horace Harker and the subscribers of the Central
+Press Syndicate. Now, Watson, I think that we shall find that we
+have a long and rather complex day’s work before us. I should be
+glad, Lestrade, if you could make it convenient to meet us at
+Baker Street at six o’clock this evening. Until then I should
+like to keep this photograph, found in the dead man’s pocket. It
+is possible that I may have to ask your company and assistance
+upon a small expedition which will have be undertaken to-night,
+if my chain of reasoning should prove to be correct. Until then
+good-bye and good luck!”
+
+Sherlock Holmes and I walked together to the High Street, where
+we stopped at the shop of Harding Brothers, whence the bust had
+been purchased. A young assistant informed us that Mr. Harding
+would be absent until afternoon, and that he was himself a
+newcomer, who could give us no information. Holmes’s face showed
+his disappointment and annoyance.
+
+“Well, well, we can’t expect to have it all our own way, Watson,”
+he said, at last. “We must come back in the afternoon, if Mr.
+Harding will not be here until then. I am, as you have no doubt
+surmised, endeavouring to trace these busts to their source, in
+order to find if there is not something peculiar which may
+account for their remarkable fate. Let us make for Mr. Morse
+Hudson, of the Kennington Road, and see if he can throw any light
+upon the problem.”
+
+A drive of an hour brought us to the picture-dealer’s
+establishment. He was a small, stout man with a red face and a
+peppery manner.
+
+“Yes, sir. On my very counter, sir,” said he. “What we pay rates
+and taxes for I don’t know, when any ruffian can come in and
+break one’s goods. Yes, sir, it was I who sold Dr. Barnicot his
+two statues. Disgraceful, sir! A Nihilist plot—that’s what I make
+it. No one but an anarchist would go about breaking statues. Red
+republicans—that’s what I call ’em. Who did I get the statues
+from? I don’t see what that has to do with it. Well, if you
+really want to know, I got them from Gelder & Co., in Church
+Street, Stepney. They are a well-known house in the trade, and
+have been this twenty years. How many had I? Three—two and one
+are three—two of Dr. Barnicot’s, and one smashed in broad
+daylight on my own counter. Do I know that photograph? No, I
+don’t. Yes, I do, though. Why, it’s Beppo. He was a kind of
+Italian piece-work man, who made himself useful in the shop. He
+could carve a bit, and gild and frame, and do odd jobs. The
+fellow left me last week, and I’ve heard nothing of him since.
+No, I don’t know where he came from nor where he went to. I had
+nothing against him while he was here. He was gone two days
+before the bust was smashed.”
+
+“Well, that’s all we could reasonably expect from Morse Hudson,”
+said Holmes, as we emerged from the shop. “We have this Beppo as
+a common factor, both in Kennington and in Kensington, so that is
+worth a ten-mile drive. Now, Watson, let us make for Gelder &
+Co., of Stepney, the source and origin of the busts. I shall be
+surprised if we don’t get some help down there.”
+
+In rapid succession we passed through the fringe of fashionable
+London, hotel London, theatrical London, literary London,
+commercial London, and, finally, maritime London, till we came to
+a riverside city of a hundred thousand souls, where the tenement
+houses swelter and reek with the outcasts of Europe. Here, in a
+broad thoroughfare, once the abode of wealthy City merchants, we
+found the sculpture works for which we searched. Outside was a
+considerable yard full of monumental masonry. Inside was a large
+room in which fifty workers were carving or moulding. The
+manager, a big blond German, received us civilly and gave a clear
+answer to all Holmes’s questions. A reference to his books showed
+that hundreds of casts had been taken from a marble copy of
+Devine’s head of Napoleon, but that the three which had been sent
+to Morse Hudson a year or so before had been half of a batch of
+six, the other three being sent to Harding Brothers, of
+Kensington. There was no reason why those six should be different
+from any of the other casts. He could suggest no possible cause
+why anyone should wish to destroy them—in fact, he laughed at the
+idea. Their wholesale price was six shillings, but the retailer
+would get twelve or more. The cast was taken in two moulds from
+each side of the face, and then these two profiles of plaster of
+Paris were joined together to make the complete bust. The work
+was usually done by Italians, in the room we were in. When
+finished, the busts were put on a table in the passage to dry,
+and afterwards stored. That was all he could tell us.
+
+But the production of the photograph had a remarkable effect upon
+the manager. His face flushed with anger, and his brows knotted
+over his blue Teutonic eyes.
+
+“Ah, the rascal!” he cried. “Yes, indeed, I know him very well.
+This has always been a respectable establishment, and the only
+time that we have ever had the police in it was over this very
+fellow. It was more than a year ago now. He knifed another
+Italian in the street, and then he came to the works with the
+police on his heels, and he was taken here. Beppo was his
+name—his second name I never knew. Serve me right for engaging a
+man with such a face. But he was a good workman—one of the best.”
+
+“What did he get?”
+
+“The man lived and he got off with a year. I have no doubt he is
+out now, but he has not dared to show his nose here. We have a
+cousin of his here, and I daresay he could tell you where he is.”
+
+“No, no,” cried Holmes, “not a word to the cousin—not a word, I
+beg of you. The matter is very important, and the farther I go
+with it, the more important it seems to grow. When you referred
+in your ledger to the sale of those casts I observed that the
+date was June 3rd of last year. Could you give me the date when
+Beppo was arrested?”
+
+“I could tell you roughly by the pay-list,” the manager answered.
+“Yes,” he continued, after some turning over of pages, “he was
+paid last on May 20th.”
+
+“Thank you,” said Holmes. “I don’t think that I need intrude upon
+your time and patience any more.” With a last word of caution
+that he should say nothing as to our researches, we turned our
+faces westward once more.
+
+The afternoon was far advanced before we were able to snatch a
+hasty luncheon at a restaurant. A news-bill at the entrance
+announced “Kensington Outrage. Murder by a Madman,” and the
+contents of the paper showed that Mr. Horace Harker had got his
+account into print after all. Two columns were occupied with a
+highly sensational and flowery rendering of the whole incident.
+Holmes propped it against the cruet-stand and read it while he
+ate. Once or twice he chuckled.
+
+“This is all right, Watson,” said he. “Listen to this:
+
+“It is satisfactory to know that there can be no difference of
+opinion upon this case, since Mr. Lestrade, one of the most
+experienced members of the official force, and Mr. Sherlock
+Holmes, the well-known consulting expert, have each come to the
+conclusion that the grotesque series of incidents, which have
+ended in so tragic a fashion, arise from lunacy rather than from
+deliberate crime. No explanation save mental aberration can cover
+the facts.
+
+“The Press, Watson, is a most valuable institution, if you only
+know how to use it. And now, if you have quite finished, we will
+hark back to Kensington and see what the manager of Harding
+Brothers has to say on the matter.”
+
+The founder of that great emporium proved to be a brisk, crisp
+little person, very dapper and quick, with a clear head and a
+ready tongue.
+
+“Yes, sir, I have already read the account in the evening papers.
+Mr. Horace Harker is a customer of ours. We supplied him with the
+bust some months ago. We ordered three busts of that sort from
+Gelder & Co., of Stepney. They are all sold now. To whom? Oh, I
+daresay by consulting our sales book we could very easily tell
+you. Yes, we have the entries here. One to Mr. Harker you see,
+and one to Mr. Josiah Brown, of Laburnum Lodge, Laburnum Vale,
+Chiswick, and one to Mr. Sandeford, of Lower Grove Road, Reading.
+No, I have never seen this face which you show me in the
+photograph. You would hardly forget it, would you, sir, for I’ve
+seldom seen an uglier. Have we any Italians on the staff? Yes,
+sir, we have several among our workpeople and cleaners. I daresay
+they might get a peep at that sales book if they wanted to. There
+is no particular reason for keeping a watch upon that book. Well,
+well, it’s a very strange business, and I hope that you will let
+me know if anything comes of your inquiries.”
+
+Holmes had taken several notes during Mr. Harding’s evidence, and
+I could see that he was thoroughly satisfied by the turn which
+affairs were taking. He made no remark, however, save that,
+unless we hurried, we should be late for our appointment with
+Lestrade. Sure enough, when we reached Baker Street the detective
+was already there, and we found him pacing up and down in a fever
+of impatience. His look of importance showed that his day’s work
+had not been in vain.
+
+“Well?” he asked. “What luck, Mr. Holmes?”
+
+“We have had a very busy day, and not entirely a wasted one,” my
+friend explained. “We have seen both the retailers and also the
+wholesale manufacturers. I can trace each of the busts now from
+the beginning.”
+
+“The busts,” cried Lestrade. “Well, well, you have your own
+methods, Mr. Sherlock Holmes, and it is not for me to say a word
+against them, but I think I have done a better day’s work than
+you. I have identified the dead man.”
+
+“You don’t say so?”
+
+“And found a cause for the crime.”
+
+“Splendid!”
+
+“We have an inspector who makes a specialty of Saffron Hill and
+the Italian Quarter. Well, this dead man had some Catholic emblem
+round his neck, and that, along with his colour, made me think he
+was from the South. Inspector Hill knew him the moment he caught
+sight of him. His name is Pietro Venucci, from Naples, and he is
+one of the greatest cut-throats in London. He is connected with
+the Mafia, which, as you know, is a secret political society,
+enforcing its decrees by murder. Now, you see how the affair
+begins to clear up. The other fellow is probably an Italian also,
+and a member of the Mafia. He has broken the rules in some
+fashion. Pietro is set upon his track. Probably the photograph we
+found in his pocket is the man himself, so that he may not knife
+the wrong person. He dogs the fellow, he sees him enter a house,
+he waits outside for him, and in the scuffle he receives his own
+death-wound. How is that, Mr. Sherlock Holmes?”
+
+Holmes clapped his hands approvingly.
+
+“Excellent, Lestrade, excellent!” he cried. “But I didn’t quite
+follow your explanation of the destruction of the busts.”
+
+“The busts! You never can get those busts out of your head. After
+all, that is nothing; petty larceny, six months at the most. It
+is the murder that we are really investigating, and I tell you
+that I am gathering all the threads into my hands.”
+
+“And the next stage?”
+
+“Is a very simple one. I shall go down with Hill to the Italian
+Quarter, find the man whose photograph we have got, and arrest
+him on the charge of murder. Will you come with us?”
+
+“I think not. I fancy we can attain our end in a simpler way. I
+can’t say for certain, because it all depends—well, it all
+depends upon a factor which is completely outside our control.
+But I have great hopes—in fact, the betting is exactly two to
+one—that if you will come with us to-night I shall be able to
+help you to lay him by the heels.”
+
+“In the Italian Quarter?”
+
+“No, I fancy Chiswick is an address which is more likely to find
+him. If you will come with me to Chiswick to-night, Lestrade,
+I’ll promise to go to the Italian Quarter with you to-morrow, and
+no harm will be done by the delay. And now I think that a few
+hours’ sleep would do us all good, for I do not propose to leave
+before eleven o’clock, and it is unlikely that we shall be back
+before morning. You’ll dine with us, Lestrade, and then you are
+welcome to the sofa until it is time for us to start. In the
+meantime, Watson, I should be glad if you would ring for an
+express messenger, for I have a letter to send and it is
+important that it should go at once.”
+
+Holmes spent the evening in rummaging among the files of the old
+daily papers with which one of our lumber-rooms was packed. When
+at last he descended, it was with triumph in his eyes, but he
+said nothing to either of us as to the result of his researches.
+For my own part, I had followed step by step the methods by which
+he had traced the various windings of this complex case, and,
+though I could not yet perceive the goal which we would reach, I
+understood clearly that Holmes expected this grotesque criminal
+to make an attempt upon the two remaining busts, one of which, I
+remembered, was at Chiswick. No doubt the object of our journey
+was to catch him in the very act, and I could not but admire the
+cunning with which my friend had inserted a wrong clue in the
+evening paper, so as to give the fellow the idea that he could
+continue his scheme with impunity. I was not surprised when
+Holmes suggested that I should take my revolver with me. He had
+himself picked up the loaded hunting-crop, which was his
+favourite weapon.
+
+A four-wheeler was at the door at eleven, and in it we drove to a
+spot at the other side of Hammersmith Bridge. Here the cabman was
+directed to wait. A short walk brought us to a secluded road
+fringed with pleasant houses, each standing in its own grounds.
+In the light of a street lamp we read “Laburnum Villa” upon the
+gate-post of one of them. The occupants had evidently retired to
+rest, for all was dark save for a fanlight over the hall door,
+which shed a single blurred circle on to the garden path. The
+wooden fence which separated the grounds from the road threw a
+dense black shadow upon the inner side, and here it was that we
+crouched.
+
+“I fear that you’ll have a long wait,” Holmes whispered. “We may
+thank our stars that it is not raining. I don’t think we can even
+venture to smoke to pass the time. However, it’s a two to one
+chance that we get something to pay us for our trouble.”
+
+It proved, however, that our vigil was not to be so long as
+Holmes had led us to fear, and it ended in a very sudden and
+singular fashion. In an instant, without the least sound to warn
+us of his coming, the garden gate swung open, and a lithe, dark
+figure, as swift and active as an ape, rushed up the garden path.
+We saw it whisk past the light thrown from over the door and
+disappear against the black shadow of the house. There was a long
+pause, during which we held our breath, and then a very gentle
+creaking sound came to our ears. The window was being opened. The
+noise ceased, and again there was a long silence. The fellow was
+making his way into the house. We saw the sudden flash of a dark
+lantern inside the room. What he sought was evidently not there,
+for again we saw the flash through another blind, and then
+through another.
+
+“Let us get to the open window. We will nab him as he climbs
+out,” Lestrade whispered.
+
+But before we could move, the man had emerged again. As he came
+out into the glimmering patch of light, we saw that he carried
+something white under his arm. He looked stealthily all round
+him. The silence of the deserted street reassured him. Turning
+his back upon us he laid down his burden, and the next instant
+there was the sound of a sharp tap, followed by a clatter and
+rattle. The man was so intent upon what he was doing that he
+never heard our steps as we stole across the grass plot. With the
+bound of a tiger Holmes was on his back, and an instant later
+Lestrade and I had him by either wrist, and the handcuffs had
+been fastened. As we turned him over I saw a hideous, sallow
+face, with writhing, furious features, glaring up at us, and I
+knew that it was indeed the man of the photograph whom we had
+secured.
+
+But it was not our prisoner to whom Holmes was giving his
+attention. Squatted on the doorstep, he was engaged in most
+carefully examining that which the man had brought from the
+house. It was a bust of Napoleon, like the one which we had seen
+that morning, and it had been broken into similar fragments.
+Carefully Holmes held each separate shard to the light, but in no
+way did it differ from any other shattered piece of plaster. He
+had just completed his examination when the hall lights flew up,
+the door opened, and the owner of the house, a jovial, rotund
+figure in shirt and trousers, presented himself.
+
+“Mr. Josiah Brown, I suppose?” said Holmes.
+
+“Yes, sir; and you, no doubt, are Mr. Sherlock Holmes? I had the
+note which you sent by the express messenger, and I did exactly
+what you told me. We locked every door on the inside and awaited
+developments. Well, I’m very glad to see that you have got the
+rascal. I hope, gentlemen, that you will come in and have some
+refreshment.”
+
+However, Lestrade was anxious to get his man into safe quarters,
+so within a few minutes our cab had been summoned and we were all
+four upon our way to London. Not a word would our captive say,
+but he glared at us from the shadow of his matted hair, and once,
+when my hand seemed within his reach, he snapped at it like a
+hungry wolf. We stayed long enough at the police-station to learn
+that a search of his clothing revealed nothing save a few
+shillings and a long sheath knife, the handle of which bore
+copious traces of recent blood.
+
+“That’s all right,” said Lestrade, as we parted. “Hill knows all
+these gentry, and he will give a name to him. You’ll find that my
+theory of the Mafia will work out all right. But I’m sure I am
+exceedingly obliged to you, Mr. Holmes, for the workmanlike way
+in which you laid hands upon him. I don’t quite understand it all
+yet.”
+
+“I fear it is rather too late an hour for explanations,” said
+Holmes. “Besides, there are one or two details which are not
+finished off, and it is one of those cases which are worth
+working out to the very end. If you will come round once more to
+my rooms at six o’clock to-morrow, I think I shall be able to
+show you that even now you have not grasped the entire meaning of
+this business, which presents some features which make it
+absolutely original in the history of crime. If ever I permit you
+to chronicle any more of my little problems, Watson, I foresee
+that you will enliven your pages by an account of the singular
+adventure of the Napoleonic busts.”
+
+When we met again next evening, Lestrade was furnished with much
+information concerning our prisoner. His name, it appeared, was
+Beppo, second name unknown. He was a well-known ne’er-do-well
+among the Italian colony. He had once been a skilful sculptor and
+had earned an honest living, but he had taken to evil courses and
+had twice already been in jail—once for a petty theft, and once,
+as we had already heard, for stabbing a fellow-countryman. He
+could talk English perfectly well. His reasons for destroying the
+busts were still unknown, and he refused to answer any questions
+upon the subject, but the police had discovered that these same
+busts might very well have been made by his own hands, since he
+was engaged in this class of work at the establishment of Gelder
+& Co. To all this information, much of which we already knew,
+Holmes listened with polite attention, but I, who knew him so
+well, could clearly see that his thoughts were elsewhere, and I
+detected a mixture of mingled uneasiness and expectation beneath
+that mask which he was wont to assume. At last he started in his
+chair, and his eyes brightened. There had been a ring at the
+bell. A minute later we heard steps upon the stairs, and an
+elderly red-faced man with grizzled side-whiskers was ushered in.
+In his right hand he carried an old-fashioned carpet-bag, which
+he placed upon the table.
+
+“Is Mr. Sherlock Holmes here?”
+
+My friend bowed and smiled. “Mr. Sandeford, of Reading, I
+suppose?” said he.
+
+“Yes, sir, I fear that I am a little late, but the trains were
+awkward. You wrote to me about a bust that is in my possession.”
+
+“Exactly.”
+
+“I have your letter here. You said, ‘I desire to possess a copy
+of Devine’s Napoleon, and am prepared to pay you ten pounds for
+the one which is in your possession.’ Is that right?”
+
+“Certainly.”
+
+“I was very much surprised at your letter, for I could not
+imagine how you knew that I owned such a thing.”
+
+“Of course you must have been surprised, but the explanation is
+very simple. Mr. Harding, of Harding Brothers, said that they had
+sold you their last copy, and he gave me your address.”
+
+“Oh, that was it, was it? Did he tell you what I paid for it?”
+
+“No, he did not.”
+
+“Well, I am an honest man, though not a very rich one. I only
+gave fifteen shillings for the bust, and I think you ought to
+know that before I take ten pounds from you.
+
+“I am sure the scruple does you honour, Mr. Sandeford. But I have
+named that price, so I intend to stick to it.”
+
+“Well, it is very handsome of you, Mr. Holmes. I brought the bust
+up with me, as you asked me to do. Here it is!” He opened his
+bag, and at last we saw placed upon our table a complete specimen
+of that bust which we had already seen more than once in
+fragments.
+
+Holmes took a paper from his pocket and laid a ten-pound note
+upon the table.
+
+“You will kindly sign that paper, Mr. Sandeford, in the presence
+of these witnesses. It is simply to say that you transfer every
+possible right that you ever had in the bust to me. I am a
+methodical man, you see, and you never know what turn events
+might take afterwards. Thank you, Mr. Sandeford; here is your
+money, and I wish you a very good evening.”
+
+When our visitor had disappeared, Sherlock Holmes’s movements
+were such as to rivet our attention. He began by taking a clean
+white cloth from a drawer and laying it over the table. Then he
+placed his newly acquired bust in the centre of the cloth.
+Finally, he picked up his hunting-crop and struck Napoleon a
+sharp blow on the top of the head. The figure broke into
+fragments, and Holmes bent eagerly over the shattered remains.
+Next instant, with a loud shout of triumph he held up one
+splinter, in which a round, dark object was fixed like a plum in
+a pudding.
+
+“Gentlemen,” he cried, “let me introduce you to the famous black
+pearl of the Borgias.”
+
+Lestrade and I sat silent for a moment, and then, with a
+spontaneous impulse, we both broke at clapping, as at the
+well-wrought crisis of a play. A flush of colour sprang to
+Holmes’s pale cheeks, and he bowed to us like the master
+dramatist who receives the homage of his audience. It was at such
+moments that for an instant he ceased to be a reasoning machine,
+and betrayed his human love for admiration and applause. The same
+singularly proud and reserved nature which turned away with
+disdain from popular notoriety was capable of being moved to its
+depths by spontaneous wonder and praise from a friend.
+
+“Yes, gentlemen,” said he, “it is the most famous pearl now
+existing in the world, and it has been my good fortune, by a
+connected chain of inductive reasoning, to trace it from the
+Prince of Colonna’s bedroom at the Dacre Hotel, where it was
+lost, to the interior of this, the last of the six busts of
+Napoleon which were manufactured by Gelder & Co., of Stepney. You
+will remember, Lestrade, the sensation caused by the
+disappearance of this valuable jewel and the vain efforts of the
+London police to recover it. I was myself consulted upon the
+case, but I was unable to throw any light upon it. Suspicion fell
+upon the maid of the Princess, who was an Italian, and it was
+proved that she had a brother in London, but we failed to trace
+any connection between them. The maid’s name was Lucretia
+Venucci, and there is no doubt in my mind that this Pietro who
+was murdered two nights ago was the brother. I have been looking
+up the dates in the old files of the paper, and I find that the
+disappearance of the pearl was exactly two days before the arrest
+of Beppo, for some crime of violence—an event which took place in
+the factory of Gelder & Co., at the very moment when these busts
+were being made. Now you clearly see the sequence of events,
+though you see them, of course, in the inverse order to the way
+in which they presented themselves to me. Beppo had the pearl in
+his possession. He may have stolen it from Pietro, he may have
+been Pietro’s confederate, he may have been the go-between of
+Pietro and his sister. It is of no consequence to us which is the
+correct solution.
+
+“The main fact is that he _had_ the pearl, and at that moment,
+when it was on his person, he was pursued by the police. He made
+for the factory in which he worked, and he knew that he had only
+a few minutes in which to conceal this enormously valuable prize,
+which would otherwise be found on him when he was searched. Six
+plaster casts of Napoleon were drying in the passage. One of them
+was still soft. In an instant Beppo, a skilful workman, made a
+small hole in the wet plaster, dropped in the pearl, and with a
+few touches covered over the aperture once more. It was an
+admirable hiding-place. No one could possibly find it. But Beppo
+was condemned to a year’s imprisonment, and in the meanwhile his
+six busts were scattered over London. He could not tell which
+contained his treasure. Only by breaking them could he see. Even
+shaking would tell him nothing, for as the plaster was wet it was
+probable that the pearl would adhere to it—as, in fact, it has
+done. Beppo did not despair, and he conducted his search with
+considerable ingenuity and perseverance. Through a cousin who
+works with Gelder, he found out the retail firms who had bought
+the busts. He managed to find employment with Morse Hudson, and
+in that way tracked down three of them. The pearl was not there.
+Then, with the help of some Italian employee, he succeeded in
+finding out where the other three busts had gone. The first was
+at Harker’s. There he was dogged by his confederate, who held
+Beppo responsible for the loss of the pearl, and he stabbed him
+in the scuffle which followed.”
+
+“If he was his confederate, why should he carry his photograph?”
+I asked.
+
+“As a means of tracing him, if he wished to inquire about him
+from any third person. That was the obvious reason. Well, after
+the murder I calculated that Beppo would probably hurry rather
+than delay his movements. He would fear that the police would
+read his secret, and so he hastened on before they should get
+ahead of him. Of course, I could not say that he had not found
+the pearl in Harker’s bust. I had not even concluded for certain
+that it was the pearl, but it was evident to me that he was
+looking for something, since he carried the bust past the other
+houses in order to break it in the garden which had a lamp
+overlooking it. Since Harker’s bust was one in three, the chances
+were exactly as I told you—two to one against the pearl being
+inside it. There remained two busts, and it was obvious that he
+would go for the London one first. I warned the inmates of the
+house, so as to avoid a second tragedy, and we went down, with
+the happiest results. By that time, of course, I knew for certain
+that it was the Borgia pearl that we were after. The name of the
+murdered man linked the one event with the other. There only
+remained a single bust—the Reading one—and the pearl must be
+there. I bought it in your presence from the owner—and there it
+lies.”
+
+We sat in silence for a moment.
+
+“Well,” said Lestrade, “I’ve seen you handle a good many cases,
+Mr. Holmes, but I don’t know that I ever knew a more workmanlike
+one than that. We’re not jealous of you at Scotland Yard. No,
+sir, we are very proud of you, and if you come down to-morrow,
+there’s not a man, from the oldest inspector to the youngest
+constable, who wouldn’t be glad to shake you by the hand.”
+
+“Thank you!” said Holmes. “Thank you!” and as he turned away, it
+seemed to me that he was more nearly moved by the softer human
+emotions than I had ever seen him. A moment later he was the cold
+and practical thinker once more. “Put the pearl in the safe,
+Watson,” said he, “and get out the papers of the Conk-Singleton
+forgery case. Good-bye, Lestrade. If any little problem comes
+your way, I shall be happy, if I can, to give you a hint or two
+as to its solution.”

--- a/examples/test/The Adventure of the Speckled Band.txt
+++ b/examples/test/The Adventure of the Speckled Band.txt
@@ -1,0 +1,1140 @@
+THE ADVENTURE OF THE SPECKLED BAND
+
+
+On glancing over my notes of the seventy odd cases in which I have
+during the last eight years studied the methods of my friend Sherlock
+Holmes, I find many tragic, some comic, a large number merely strange,
+but none commonplace; for, working as he did rather for the love of his
+art than for the acquirement of wealth, he refused to associate himself
+with any investigation which did not tend towards the unusual, and even
+the fantastic. Of all these varied cases, however, I cannot recall any
+which presented more singular features than that which was associated
+with the well-known Surrey family of the Roylotts of Stoke Moran. The
+events in question occurred in the early days of my association with
+Holmes, when we were sharing rooms as bachelors in Baker Street. It
+is possible that I might have placed them upon record before, but a
+promise of secrecy was made at the time, from which I have only been
+freed during the last month by the untimely death of the lady to whom
+the pledge was given. It is perhaps as well that the facts should now
+come to light, for I have reasons to know that there are wide-spread
+rumors as to the death of Dr. Grimesby Roylott which tend to make the
+matter even more terrible than the truth.
+
+It was early in April in the year ’83 that I woke one morning to find
+Sherlock Holmes standing, fully dressed, by the side of my bed. He was
+a late riser as a rule, and as the clock on the mantel-piece showed
+me that it was only a quarter past seven, I blinked up at him in some
+surprise, and perhaps just a little resentment, for I was myself
+regular in my habits.
+
+“Very sorry to knock you up, Watson,” said he, “but it’s the common lot
+this morning. Mrs. Hudson has been knocked up, she retorted upon me,
+and I on you.”
+
+“What is it, then—a fire?”
+
+“No; a client. It seems that a young lady has arrived in a considerable
+state of excitement, who insists upon seeing me. She is waiting now in
+the sitting-room. Now, when young ladies wander about the metropolis
+at this hour of the morning, and knock sleepy people up out of their
+beds, I presume that it is something very pressing which they have to
+communicate. Should it prove to be an interesting case, you would, I am
+sure, wish to follow it from the outset. I thought, at any rate, that I
+should call you and give you the chance.”
+
+“My dear fellow, I would not miss it for anything.”
+
+I had no keener pleasure than in following Holmes in his professional
+investigations, and in admiring the rapid deductions, as swift as
+intuitions, and yet always founded on a logical basis, with which he
+unravelled the problems which were submitted to him. I rapidly threw on
+my clothes, and was ready in a few minutes to accompany my friend down
+to the sitting-room. A lady dressed in black and heavily veiled, who
+had been sitting in the window, rose as we entered.
+
+“Good-morning, madam,” said Holmes, cheerily. “My name is Sherlock
+Holmes. This is my intimate friend and associate, Dr. Watson, before
+whom you can speak as freely as before myself. Ha! I am glad to see
+that Mrs. Hudson has had the good sense to light the fire. Pray draw up
+to it, and I shall order you a cup of hot coffee, for I observe that
+you are shivering.”
+
+“It is not cold which makes me shiver,” said the woman, in a low voice,
+changing her seat as requested.
+
+“What, then?”
+
+“It is fear, Mr. Holmes. It is terror.” She raised her veil as she
+spoke, and we could see that she was indeed in a pitiable state of
+agitation, her face all drawn and gray, with restless, frightened eyes,
+like those of some hunted animal. Her features and figure were those of
+a woman of thirty, but her hair was shot with premature gray, and her
+expression was weary and haggard. Sherlock Holmes ran her over with one
+of his quick, all-comprehensive glances.
+
+“You must not fear,” said he, soothingly, bending forward and patting
+her forearm. “We shall soon set matters right, I have no doubt. You
+have come in by train this morning, I see.”
+
+“You know me, then?”
+
+“No, but I observe the second half of a return ticket in the palm of
+your left glove. You must have started early, and yet you had a good
+drive in a dog-cart, along heavy roads, before you reached the station.”
+
+The lady gave a violent start, and stared in bewilderment at my
+companion.
+
+“There is no mystery, my dear madam,” said he, smiling. “The left arm
+of your jacket is spattered with mud in no less than seven places. The
+marks are perfectly fresh. There is no vehicle save a dog-cart which
+throws up mud in that way, and then only when you sit on the left-hand
+side of the driver.”
+
+“Whatever your reasons may be, you are perfectly correct,” said she. “I
+started from home before six, reached Leatherhead at twenty past, and
+came in by the first train to Waterloo. Sir, I can stand this strain no
+longer; I shall go mad if it continues. I have no one to turn to—none,
+save only one, who cares for me, and he, poor fellow, can be of little
+aid. I have heard of you, Mr. Holmes; I have heard of you from Mrs.
+Farintosh, whom you helped in the hour of her sore need. It was from
+her that I had your address. Oh, sir, do you not think that you could
+help me, too, and at least throw a little light through the dense
+darkness which surrounds me? At present it is out of my power to reward
+you for your services, but in a month or six weeks I shall be married,
+with the control of my own income, and then at least you shall not
+find me ungrateful.”
+
+Holmes turned to his desk, and unlocking it, drew out a small
+case-book, which he consulted.
+
+“Farintosh,” said he. “Ah yes, I recall the case; it was concerned with
+an opal tiara. I think it was before your time, Watson. I can only say,
+madam, that I shall be happy to devote the same care to your case as
+I did to that of your friend. As to reward, my profession is its own
+reward; but you are at liberty to defray whatever expenses I may be put
+to, at the time which suits you best. And now I beg that you will lay
+before us everything that may help us in forming an opinion upon the
+matter.”
+
+“Alas!” replied our visitor, “the very horror of my situation lies
+in the fact that my fears are so vague, and my suspicions depend so
+entirely upon small points, which might seem trivial to another, that
+even he to whom of all others I have a right to look for help and
+advice looks upon all that I tell him about it as the fancies of a
+nervous woman. He does not say so, but I can read it from his soothing
+answers and averted eyes. But I have heard, Mr. Holmes, that you can
+see deeply into the manifold wickedness of the human heart. You may
+advise me how to walk amid the dangers which encompass me.”
+
+“I am all attention, madam.”
+
+“My name is Helen Stoner, and I am living with my step-father, who is
+the last survivor of one of the oldest Saxon families in England, the
+Roylotts of Stoke Moran, on the western border of Surrey.”
+
+Holmes nodded his head. “The name is familiar to me,” said he.
+
+“The family was at one time among the richest in England, and the
+estates extended over the borders into Berkshire in the north, and
+Hampshire in the west. In the last century, however, four successive
+heirs were of a dissolute and wasteful disposition, and the family
+ruin was eventually completed by a gambler in the days of the
+Regency. Nothing was left save a few acres of ground, and the
+two-hundred-year-old house, which is itself crushed under a heavy
+mortgage. The last squire dragged out his existence there, living
+the horrible life of an aristocratic pauper; but his only son, my
+step-father, seeing that he must adapt himself to the new conditions,
+obtained an advance from a relative, which enabled him to take a
+medical degree, and went out to Calcutta, where, by his professional
+skill and his force of character, he established a large practice.
+In a fit of anger, however, caused by some robberies which had been
+perpetrated in the house, he beat his native butler to death, and
+narrowly escaped a capital sentence. As it was, he suffered a long
+term of imprisonment, and afterwards returned to England a morose and
+disappointed man.
+
+“When Dr. Roylott was in India he married my mother, Mrs. Stoner, the
+young widow of Major-general Stoner, of the Bengal Artillery. My sister
+Julia and I were twins, and we were only two years old at the time of
+my mother’s re-marriage. She had a considerable sum of money—not less
+than £1000 a year—and this she bequeathed to Dr. Roylott entirely
+while we resided with him, with a provision that a certain annual sum
+should be allowed to each of us in the event of our marriage. Shortly
+after our return to England my mother died—she was killed eight years
+ago in a railway accident near Crewe. Dr. Roylott then abandoned his
+attempts to establish himself in practice in London, and took us to
+live with him in the old ancestral house at Stoke Moran. The money
+which my mother had left was enough for all our wants, and there seemed
+to be no obstacle to our happiness.
+
+“But a terrible change came over our step-father about this time.
+Instead of making friends and exchanging visits with our neighbors, who
+had at first been overjoyed to see a Roylott of Stoke Moran back in
+the old family seat, he shut himself up in his house, and seldom came
+out save to indulge in ferocious quarrels with whoever might cross his
+path. Violence of temper approaching to mania has been hereditary in
+the men of the family, and in my step-father’s case it had, I believe,
+been intensified by his long residence in the tropics. A series of
+disgraceful brawls took place, two of which ended in the police-court,
+until at last he became the terror of the village, and the folks
+would fly at his approach, for he is a man of immense strength, and
+absolutely uncontrollable in his anger.
+
+“Last week he hurled the local blacksmith over a parapet into a stream,
+and it was only by paying over all the money which I could gather
+together that I was able to avert another public exposure. He had no
+friends at all save the wandering gypsies, and he would give these
+vagabonds leave to encamp upon the few acres of bramble-covered land
+which represent the family estate, and would accept in return the
+hospitality of their tents, wandering away with them sometimes for
+weeks on end. He has a passion also for Indian animals, which are sent
+over to him by a correspondent, and he has at this moment a cheetah and
+a baboon, which wander freely over his grounds, and are feared by the
+villagers almost as much as their master.
+
+“You can imagine from what I say that my poor sister Julia and I had no
+great pleasure in our lives. No servant would stay with us, and for a
+long time we did all the work of the house. She was but thirty at the
+time of her death, and yet her hair had already begun to whiten, even
+as mine has.”
+
+“Your sister is dead, then?”
+
+“She died just two years ago, and it is of her death that I wish to
+speak to you. You can understand that, living the life which I have
+described, we were little likely to see anyone of our own age and
+position. We had, however, an aunt, my mother’s maiden sister, Miss
+Honoria Westphail, who lives near Harrow, and we were occasionally
+allowed to pay short visits at this lady’s house. Julia went there at
+Christmas two years ago, and met there a half-pay major of marines,
+to whom she became engaged. My step-father learned of the engagement
+when my sister returned, and offered no objection to the marriage; but
+within a fortnight of the day which had been fixed for the wedding, the
+terrible event occurred which has deprived me of my only companion.”
+
+Sherlock Holmes had been leaning back in his chair with his eyes closed
+and his head sunk in a cushion, but he half opened his lids now and
+glanced across at his visitor.
+
+“Pray be precise as to details,” said he.
+
+“It is easy for me to be so, for every event of that dreadful time is
+seared into my memory. The manor-house is, as I have already said, very
+old, and only one wing is now inhabited. The bedrooms in this wing are
+on the ground floor, the sitting-rooms being in the central block of
+the buildings. Of these bedrooms the first is Dr. Roylott’s, the second
+my sister’s, and the third my own. There is no communication between
+them, but they all open out into the same corridor. Do I make myself
+plain?”
+
+“Perfectly so.”
+
+“The windows of the three rooms open out upon the lawn. That fatal
+night Dr. Roylott had gone to his room early, though we knew that he
+had not retired to rest, for my sister was troubled by the smell of
+the strong Indian cigars which it was his custom to smoke. She left
+her room, therefore, and came into mine, where she sat for some time,
+chatting about her approaching wedding. At eleven o’clock she rose to
+leave me but she paused at the door and looked back.
+
+“‘Tell me, Helen,’ said she, ‘have you ever heard any one whistle in
+the dead of the night?’
+
+“‘Never,’ said I.
+
+“‘I suppose that you could not possibly whistle, yourself, in your
+sleep?’
+
+“‘Certainly not. But why?’
+
+“‘Because during the last few nights I have always, about three in
+the morning, heard a low, clear whistle. I am a light sleeper, and it
+has awakened me. I cannot tell where it came from—perhaps from the
+next room, perhaps from the lawn. I thought that I would just ask you
+whether you had heard it.’
+
+“‘No, I have not. It must be those wretched gypsies in the plantation.’
+
+“‘Very likely. And yet if it were on the lawn, I wonder that you did
+not hear it also.’
+
+“‘Ah, but I sleep more heavily than you.’
+
+“‘Well, it is of no great consequence, at any rate.’ She smiled back at
+me, closed my door, and a few moments later I heard her key turn in the
+lock.”
+
+“Indeed,” said Holmes. “Was it your custom always to lock yourselves in
+at night?”
+
+“Always.”
+
+“And why?”
+
+“I think that I mentioned to you that the doctor kept a cheetah and a
+baboon. We had no feeling of security unless our doors were locked.”
+
+“Quite so. Pray proceed with your statement.”
+
+“I could not sleep that night. A vague feeling of impending misfortune
+impressed me. My sister and I, you will recollect, were twins, and you
+know how subtle are the links which bind two souls which are so closely
+allied. It was a wild night. The wind was howling outside, and the rain
+was beating and splashing against the windows. Suddenly, amid all the
+hubbub of the gale, there burst forth the wild scream of a terrified
+woman. I knew that it was my sister’s voice. I sprang from my bed,
+wrapped a shawl round me, and rushed into the corridor. As I opened my
+door I seemed to hear a low whistle, such as my sister described, and a
+few moments later a clanging sound, as if a mass of metal had fallen.
+As I ran down the passage, my sister’s door was unlocked, and revolved
+slowly upon its hinges. I stared at it horror-stricken, not knowing
+what was about to issue from it. By the light of the corridor-lamp I
+saw my sister appear at the opening, her face blanched with terror, her
+hands groping for help, her whole figure swaying to and fro like that
+of a drunkard. I ran to her and threw my arms round her, but at that
+moment her knees seemed to give way and she fell to the ground. She
+writhed as one who is in terrible pain, and her limbs were dreadfully
+convulsed. At first I thought that she had not recognized me, but as I
+bent over her she suddenly shrieked out in a voice which I shall never
+forget, ‘Oh, my God! Helen! It was the band! The speckled band!’ There
+was something else which she would fain have said, and she stabbed with
+her finger into the air in the direction of the doctor’s room, but a
+fresh convulsion seized her and choked her words. I rushed out, calling
+loudly for my step-father, and I met him hastening from his room in his
+dressing-gown. When he reached my sister’s side she was unconscious,
+and though he poured brandy down her throat and sent for medical aid
+from the village, all efforts were in vain, for she slowly sank and
+died without having recovered her consciousness. Such was the dreadful
+end of my beloved sister.”
+
+“One moment,” said Holmes; “are you sure about this whistle and
+metallic sound? Could you swear to it?”
+
+“That was what the county coroner asked me at the inquiry. It is my
+strong impression that I heard it, and yet, among the crash of the gale
+and the creaking of an old house, I may possibly have been deceived.”
+
+“Was your sister dressed?”
+
+“No, she was in her night-dress. In her right hand was found the
+charred stump of a match, and in her left a matchbox.”
+
+“Showing that she had struck a light and looked about her when the
+alarm took place. That is important. And what conclusions did the
+coroner come to?”
+
+“He investigated the case with great care, for Dr. Roylott’s conduct
+had long been notorious in the county, but he was unable to find any
+satisfactory cause of death. My evidence showed that the door had
+been fastened upon the inner side, and the windows were blocked by
+old-fashioned shutters with broad iron bars, which were secured every
+night. The walls were carefully sounded, and were shown to be quite
+solid all round, and the flooring was also thoroughly examined, with
+the same result. The chimney is wide, but is barred up by four large
+staples. It is certain, therefore, that my sister was quite alone when
+she met her end. Besides, there were no marks of any violence upon her.”
+
+“How about poison?”
+
+“The doctors examined her for it, but without success.”
+
+“What do you think that this unfortunate lady died of, then?”
+
+“It is my belief that she died of pure fear and nervous shock, though
+what it was that frightened her I cannot imagine.”
+
+“Were there gypsies in the plantation at the time?”
+
+“Yes, there are nearly always some there.”
+
+“Ah, and what did you gather from this allusion to a band—a speckled
+band?”
+
+“Sometimes I have thought that it was merely the wild talk of delirium,
+sometimes that it may have referred to some band of people, perhaps to
+these very gypsies in the plantation. I do not know whether the spotted
+handkerchiefs which so many of them wear over their heads might have
+suggested the strange adjective which she used.”
+
+Holmes shook his head like a man who is far from being satisfied.
+
+“These are very deep waters,” said he; “pray go on with your narrative.”
+
+“Two years have passed since then, and my life has been until lately
+lonelier than ever. A month ago, however, a dear friend, whom I have
+known for many years, has done me the honor to ask my hand in marriage.
+His name is Armitage—Percy Armitage—the second son of Mr. Armitage,
+of Crane Water, near Reading. My step-father has offered no opposition
+to the match, and we are to be married in the course of the spring. Two
+days ago some repairs were started in the west wing of the building,
+and my bedroom wall has been pierced, so that I have had to move into
+the chamber in which my sister died, and to sleep in the very bed in
+which she slept. Imagine, then, my thrill of terror when last night,
+as I lay awake, thinking over her terrible fate, I suddenly heard in
+the silence of the night the low whistle which had been the herald of
+her own death. I sprang up and lit the lamp, but nothing was to be
+seen in the room. I was too shaken to go to bed again, however, so I
+dressed, and as soon as it was daylight I slipped down, got a dog-cart
+at the ‘Crown Inn,’ which is opposite, and drove to Leatherhead, from
+whence I have come on this morning with the one object of seeing you
+and asking your advice.”
+
+“You have done wisely,” said my friend. “But have you told me all?”
+
+“Yes, all.”
+
+“Miss Roylott, you have not. You are screening your step-father.”
+
+“Why, what do you mean?”
+
+For answer Holmes pushed back the frill of black lace which fringed the
+hand that lay upon our visitor’s knee. Five little livid spots, the
+marks of four fingers and a thumb, were printed upon the white wrist.
+
+“You have been cruelly used,” said Holmes.
+
+The lady colored deeply and covered over her injured wrist. “He is a
+hard man,” she said, “and perhaps he hardly knows his own strength.”
+
+There was a long silence, during which Holmes leaned his chin upon his
+hands and stared into the crackling fire.
+
+“This is a very deep business,” he said, at last. “There are a thousand
+details which I should desire to know before I decide upon our course
+of action. Yet we have not a moment to lose. If we were to come to
+Stoke Moran to-day, would it be possible for us to see over these rooms
+without the knowledge of your step-father?”
+
+“As it happens, he spoke of coming into town to-day upon some most
+important business. It is probable that he will be away all day, and
+that there would be nothing to disturb you. We have a house-keeper
+now, but she is old and foolish, and I could easily get her out of the
+way.”
+
+“Excellent. You are not averse to this trip, Watson?”
+
+“By no means.”
+
+“Then we shall both come. What are you going to do yourself?”
+
+“I have one or two things which I would wish to do now that I am in
+town. But I shall return by the twelve o’clock train, so as to be there
+in time for your coming.”
+
+“And you may expect us early in the afternoon. I have myself some small
+business matters to attend to. Will you not wait and breakfast?”
+
+“No, I must go. My heart is lightened already since I have confided
+my trouble to you. I shall look forward to seeing you again this
+afternoon.” She dropped her thick black veil over her face and glided
+from the room.
+
+“And what do you think of it all, Watson?” asked Sherlock Holmes,
+leaning back in his chair.
+
+“It seems to me to be a most dark and sinister business.”
+
+“Dark enough and sinister enough.”
+
+“Yet if the lady is correct in saying that the flooring and walls are
+sound, and that the door, window, and chimney are impassable, then her
+sister must have been undoubtedly alone when she met her mysterious
+end.”
+
+“What becomes, then, of these nocturnal whistles, and what of the very
+peculiar words of the dying woman?”
+
+“I cannot think.”
+
+“When you combine the ideas of whistles at night, the presence of a
+band of gypsies who are on intimate terms with this old doctor, the
+fact that we have every reason to believe that the doctor has an
+interest in preventing his step-daughter’s marriage, the dying allusion
+to a band, and, finally, the fact that Miss Helen Stoner heard a
+metallic clang, which might have been caused by one of those metal bars
+which secured the shutters falling back into their place, I think that
+there is good ground to think that the mystery may be cleared along
+those lines.”
+
+“But what, then, did the gypsies do?”
+
+“I cannot imagine.”
+
+“I see many objections to any such theory.”
+
+“And so do I. It is precisely for that reason that we are going to
+Stoke Moran this day. I want to see whether the objections are fatal,
+or if they may be explained away. But what in the name of the devil!”
+
+The ejaculation had been drawn from my companion by the fact that our
+door had been suddenly dashed open, and that a huge man had framed
+himself in the aperture. His costume was a peculiar mixture of the
+professional and of the agricultural, having a black top-hat, a long
+frock-coat, and a pair of high gaiters, with a hunting-crop swinging in
+his hand. So tall was he that his hat actually brushed the cross bar
+of the doorway, and his breadth seemed to span it across from side to
+side. A large face, seared with a thousand wrinkles, burned yellow with
+the sun, and marked with every evil passion, was turned from one to the
+other of us, while his deep-set, bile-shot eyes, and his high, thin,
+fleshless nose, gave him somewhat the resemblance to a fierce old bird
+of prey.
+
+“Which of you is Holmes?” asked this apparition.
+
+“My name, sir; but you have the advantage of me,” said my companion,
+quietly.
+
+“I am Dr. Grimesby Roylott, of Stoke Moran.”
+
+“Indeed, doctor,” said Holmes, blandly. “Pray take a seat.”
+
+“I will do nothing of the kind. My step-daughter has been here. I have
+traced her. What has she been saying to you?”
+
+“It is a little cold for the time of the year,” said Holmes.
+
+“What has she been saying to you?” screamed the old man, furiously.
+
+“But I have heard that the crocuses promise well,” continued my
+companion, imperturbably.
+
+“Ha! You put me off, do you?” said our new visitor, taking a step
+forward and shaking his hunting-crop. “I know you, you scoundrel! I
+have heard of you before. You are Holmes, the meddler.”
+
+My friend smiled.
+
+“Holmes, the busybody!”
+
+His smile broadened.
+
+“Holmes, the Scotland-yard Jack-in-office!”
+
+Holmes chuckled heartily. “Your conversation is most entertaining,”
+said he. “When you go out close the door, for there is a decided
+draught.”
+
+“I will go when I have said my say. Don’t you dare to meddle with my
+affairs. I know that Miss Stoner has been here. I traced her! I am a
+dangerous man to fall foul of! See here.” He stepped swiftly forward,
+seized the poker, and bent it into a curve with his huge brown hands.
+
+“See that you keep yourself out of my grip,” he snarled, and hurling
+the twisted poker into the fireplace, he strode out of the room.
+
+“He seems a very amiable person,” said Holmes, laughing. “I am not
+quite so bulky, but if he had remained I might have shown him that my
+grip was not much more feeble than his own.” As he spoke he picked up
+the steel poker, and with a sudden effort straightened it out again.
+
+“Fancy his having the insolence to confound me with the official
+detective force! This incident gives zest to our investigation,
+however, and I only trust that our little friend will not suffer from
+her imprudence in allowing this brute to trace her. And now, Watson,
+we shall order breakfast, and afterwards I shall walk down to Doctors’
+Commons, where I hope to get some data which may help us in this
+matter.”
+
+       *       *       *       *       *
+
+It was nearly one o’clock when Sherlock Holmes returned from his
+excursion. He held in his hand a sheet of blue paper, scrawled over
+with notes and figures.
+
+“I have seen the will of the deceased wife,” said he. “To determine
+its exact meaning I have been obliged to work out the present prices
+of the investments with which it is concerned. The total income, which
+at the time of the wife’s death was little short of £1100, is now,
+through the fall in agricultural prices, not more than £750. Each
+daughter can claim an income of £250, in case of marriage. It is
+evident, therefore, that if both girls had married, this beauty would
+have had a mere pittance, while even one of them would cripple him to
+a very serious extent. My morning’s work has not been wasted, since it
+has proved that he has the very strongest motives for standing in the
+way of anything of the sort. And now, Watson, this is too serious for
+dawdling, especially as the old man is aware that we are interesting
+ourselves in his affairs; so if you are ready, we shall call a cab and
+drive to Waterloo. I should be very much obliged if you would slip your
+revolver into your pocket. An Eley’s No. 2 is an excellent argument
+with gentlemen who can twist steel pokers into knots. That and a
+tooth-brush are, I think, all that we need.”
+
+At Waterloo we were fortunate in catching a train for Leatherhead,
+where we hired a trap at the station inn, and drove for four or five
+miles through the lovely Surrey lanes. It was a perfect day, with
+a bright sun and a few fleecy clouds in the heavens. The trees and
+way-side hedges were just throwing out their first green shoots, and
+the air was full of the pleasant smell of the moist earth. To me at
+least there was a strange contrast between the sweet promise of the
+spring and this sinister quest upon which we were engaged. My companion
+sat in the front of the trap, his arms folded, his hat pulled down over
+his eyes, and his chin sunk upon his breast, buried in the deepest
+thought. Suddenly, however, he started, tapped me on the shoulder, and
+pointed over the meadows.
+
+“Look there!” said he.
+
+A heavily-timbered park stretched up in a gentle slope, thickening into
+a grove at the highest point. From amid the branches there jutted out
+the gray gables and high roof-tree of a very old mansion.
+
+“Stoke Moran?” said he.
+
+“Yes, sir, that be the house of Dr. Grimesby Roylott,” remarked the
+driver.
+
+“There is some building going on there,” said Holmes; “that is where we
+are going.”
+
+“There’s the village,” said the driver, pointing to a cluster of roofs
+some distance to the left; “but if you want to get to the house, you’ll
+find it shorter to get over this stile, and so by the foot-path over
+the fields. There it is, where the lady is walking.”
+
+“And the lady, I fancy, is Miss Stoner,” observed Holmes, shading his
+eyes. “Yes, I think we had better do as you suggest.”
+
+We got off, paid our fare, and the trap rattled back on its way to
+Leatherhead.
+
+“I thought it as well,” said Holmes, as we climbed the stile, “that
+this fellow should think we had come here as architects, or on some
+definite business. It may stop his gossip. Good-afternoon, Miss Stoner.
+You see that we have been as good as our word.”
+
+Our client of the morning had hurried forward to meet us with a face
+which spoke her joy. “I have been waiting so eagerly for you,” she
+cried, shaking hands with us warmly. “All has turned out splendidly.
+Dr. Roylott has gone to town, and it is unlikely that he will be back
+before evening.”
+
+“We have had the pleasure of making the doctor’s acquaintance,” said
+Holmes, and in a few words he sketched out what had occurred. Miss
+Stoner turned white to the lips as she listened.
+
+“Good heavens!” she cried, “he has followed me, then.”
+
+“So it appears.”
+
+“He is so cunning that I never know when I am safe from him. What will
+he say when he returns?”
+
+“He must guard himself, for he may find that there is some one more
+cunning than himself upon his track. You must lock yourself up from him
+to-night. If he is violent, we shall take you away to your aunt’s at
+Harrow. Now, we must make the best use of our time, so kindly take us
+at once to the rooms which we are to examine.”
+
+The building was of gray, lichen-blotched stone, with a high central
+portion, and two curving wings, like the claws of a crab, thrown out
+on each side. In one of these wings the windows were broken, and
+blocked with wooden boards, while the roof was partly caved in, a
+picture of ruin. The central portion was in little better repair, but
+the right-hand block was comparatively modern, and the blinds in the
+windows, with the blue smoke curling up from the chimneys, showed that
+this was where the family resided. Some scaffolding had been erected
+against the end wall, and the stone-work had been broken into, but
+there were no signs of any workmen at the moment of our visit. Holmes
+walked slowly up and down the ill-trimmed lawn, and examined with deep
+attention the outsides of the windows.
+
+“This, I take it, belongs to the room in which you used to sleep, the
+centre one to your sister’s, and the one next to the main building to
+Dr. Roylott’s chamber?”
+
+“Exactly so. But I am now sleeping in the middle one.”
+
+“Pending the alterations, as I understand. By-the-way, there does not
+seem to be any very pressing need for repairs at that end wall.”
+
+“There were none. I believe that it was an excuse to move me from my
+room.”
+
+“Ah! that is suggestive. Now, on the other side of this narrow wing
+runs the corridor from which these three rooms open. There are windows
+in it, of course?”
+
+“Yes, but very small ones. Too narrow for any one to pass through.”
+
+“As you both locked your doors at night, your rooms were unapproachable
+from that side. Now, would you have the kindness to go into your room
+and bar your shutters.”
+
+Miss Stoner did so, and Holmes, after a careful examination through
+the open window, endeavored in every way to force the shutter open,
+but without success. There was no slit through which a knife could be
+passed to raise the bar. Then with his lens he tested the hinges, but
+they were of solid iron, built firmly into the massive masonry. “Hum!”
+said he, scratching his chin in some perplexity; “my theory certainly
+presents some difficulties. No one could pass these shutters if they
+were bolted. Well, we shall see if the inside throws any light upon the
+matter.”
+
+A small side door led into the whitewashed corridor from which the
+three bedrooms opened. Holmes refused to examine the third chamber,
+so we passed at once to the second, that in which Miss Stoner was now
+sleeping, and in which her sister had met with her fate. It was a
+homely little room, with a low ceiling and a gaping fireplace, after
+the fashion of old country-houses. A brown chest of drawers stood
+in one corner, a narrow white-counterpaned bed in another, and a
+dressing-table on the left-hand side of the window. These articles,
+with two small wicker-work chairs, made up all the furniture in the
+room, save for a square of Wilton carpet in the centre. The boards
+round and the panelling of the walls were of brown, worm-eaten oak, so
+old and discolored that it may have dated from the original building of
+the house. Holmes drew one of the chairs into a corner and sat silent,
+while his eyes travelled round and round and up and down, taking in
+every detail of the apartment.
+
+“Where does that bell communicate with?” he asked, at last, pointing to
+a thick bell-rope which hung down beside the bed, the tassel actually
+lying upon the pillow.
+
+“It goes to the house-keeper’s room.”
+
+“It looks newer than the other things?”
+
+“Yes, it was only put there a couple of years ago.”
+
+“Your sister asked for it, I suppose?”
+
+“No, I never heard of her using it. We used always to get what we
+wanted for ourselves.”
+
+“Indeed, it seemed unnecessary to put so nice a bell-pull there. You
+will excuse me for a few minutes while I satisfy myself as to this
+floor.” He threw himself down upon his face with his lens in his hand,
+and crawled swiftly backward and forward, examining minutely the cracks
+between the boards. Then he did the same with the wood-work with which
+the chamber was panelled. Finally he walked over to the bed, and spent
+some time in staring at it, and in running his eye up and down the
+wall. Finally he took the bell-rope in his hand and gave it a brisk tug.
+
+“Why, it’s a dummy,” said he.
+
+“Won’t it ring?”
+
+“No, it is not even attached to a wire. This is very interesting. You
+can see now that it is fastened to a hook just above where the little
+opening for the ventilator is.”
+
+“How very absurd! I never noticed that before.”
+
+“Very strange!” muttered Holmes, pulling at the rope. “There are one or
+two very singular points about this room. For example, what a fool a
+builder must be to open a ventilator into another room, when, with the
+same trouble, he might have communicated with the outside air!”
+
+“That is also quite modern,” said the lady.
+
+“Done about the same time as the bell-rope?” remarked Holmes.
+
+“Yes, there were several little changes carried out about that time.”
+
+“They seem to have been of a most interesting character—dummy
+bell-ropes, and ventilators which do not ventilate. With your
+permission, Miss Stoner, we shall now carry our researches into the
+inner apartment.”
+
+Dr. Grimesby Roylott’s chamber was larger than that of his
+step-daughter, but was as plainly furnished. A camp-bed, a small wooden
+shelf full of books, mostly of a technical character, an arm-chair
+beside the bed, a plain wooden chair against the wall, a round table,
+and a large iron safe were the principal things which met the eye.
+Holmes walked slowly round and examined each and all of them with the
+keenest interest.
+
+“What’s in here?” he asked, tapping the safe.
+
+“My step-father’s business papers.”
+
+“Oh! you have seen inside, then?”
+
+“Only once, some years ago. I remember that it was full of papers.”
+
+“There isn’t a cat in it, for example?”
+
+“No. What a strange idea!”
+
+“Well, look at this!” He took up a small saucer of milk which stood on
+the top of it.
+
+“No; we don’t keep a cat. But there is a cheetah and a baboon.”
+
+“Ah, yes, of course! Well, a cheetah is just a big cat, and yet a
+saucer of milk does not go very far in satisfying its wants, I dare
+say. There is one point which I should wish to determine.” He squatted
+down in front of the wooden chair, and examined the seat of it with the
+greatest attention.
+
+“Thank you. That is quite settled,” said he, rising and putting his
+lens in his pocket. “Hello! Here is something interesting!”
+
+The object which had caught his eye was a small dog-lash hung on one
+corner of the bed. The lash, however, was curled upon itself, and tied
+so as to make a loop of whip-cord.
+
+“What do you make of that, Watson?”
+
+“It’s a common enough lash. But I don’t know why it should be tied.”
+
+“That is not quite so common, is it? Ah, me! it’s a wicked world,
+and when a clever man turns his brains to crime it is the worst of
+all. I think that I have seen enough now, Miss Stoner, and with your
+permission we shall walk out upon the lawn.”
+
+I had never seen my friend’s face so grim or his brow so dark as it
+was when we turned from the scene of this investigation. We had walked
+several times up and down the lawn, neither Miss Stoner nor myself
+liking to break in upon his thoughts before he roused himself from his
+reverie.
+
+“It is very essential, Miss Stoner,” said he, “that you should
+absolutely follow my advice in every respect.”
+
+“I shall most certainly do so.”
+
+“The matter is too serious for any hesitation. Your life may depend
+upon your compliance.”
+
+“I assure you that I am in your hands.”
+
+“In the first place, both my friend and I must spend the night in your
+room.”
+
+Both Miss Stoner and I gazed at him in astonishment.
+
+“Yes, it must be so. Let me explain. I believe that that is the village
+inn over there?”
+
+“Yes, that is the ‘Crown.’”
+
+“Very good. Your windows would be visible from there?”
+
+“Certainly.”
+
+“You must confine yourself to your room, on pretence of a headache,
+when your step-father comes back. Then when you hear him retire for
+the night, you must open the shutters of your window, undo the hasp,
+put your lamp there as a signal to us, and then withdraw quietly with
+everything which you are likely to want into the room which you used to
+occupy. I have no doubt that, in spite of the repairs, you could manage
+there for one night.”
+
+“Oh yes, easily.”
+
+“The rest you will leave in our hands.”
+
+“But what will you do?”
+
+“We shall spend the night in your room, and we shall investigate the
+cause of this noise which has disturbed you.”
+
+“I believe, Mr. Holmes, that you have already made up your mind,” said
+Miss Stoner, laying her hand upon my companion’s sleeve.
+
+“Perhaps I have.”
+
+“Then for pity’s sake tell me what was the cause of my sister’s death.”
+
+“I should prefer to have clearer proofs before I speak.”
+
+“You can at least tell me whether my own thought is correct, and if she
+died from some sudden fright.”
+
+[Illustration: “‘GOOD-BYE, AND BE BRAVE’”]
+
+“No, I do not think so. I think that there was probably some more
+tangible cause. And now, Miss Stoner, we must leave you, for if Dr.
+Roylott returned and saw us, our journey would be in vain. Good-bye,
+and be brave, for if you will do what I have told you, you may rest
+assured that we shall soon drive away the dangers that threaten you.”
+
+Sherlock Holmes and I had no difficulty in engaging a bedroom and
+sitting-room at the “Crown Inn.” They were on the upper floor, and
+from our window we could command a view of the avenue gate, and of the
+inhabited wing of Stoke Moran Manor House. At dusk we saw Dr. Grimesby
+Roylott drive past, his huge form looming up beside the little figure
+of the lad who drove him. The boy had some slight difficulty in undoing
+the heavy iron gates, and we heard the hoarse roar of the doctor’s
+voice, and saw the fury with which he shook his clinched fists at him.
+The trap drove on, and a few minutes later we saw a sudden light spring
+up among the trees as the lamp was lit in one of the sitting-rooms.
+
+“Do you know, Watson,” said Holmes, as we sat together in the gathering
+darkness, “I have really some scruples as to taking you to-night. There
+is a distinct element of danger.”
+
+“Can I be of assistance?”
+
+“Your presence might be invaluable.”
+
+“Then I shall certainly come.”
+
+“It is very kind of you.”
+
+“You speak of danger. You have evidently seen more in these rooms than
+was visible to me.”
+
+“No, but I fancy that I may have deduced a little more. I imagine that
+you saw all that I did.”
+
+“I saw nothing remarkable save the bell-rope, and what purpose that
+could answer I confess is more than I can imagine.”
+
+“You saw the ventilator, too?”
+
+“Yes, but I do not think that it is such a very unusual thing to have
+a small opening between two rooms. It was so small that a rat could
+hardly pass through.”
+
+“I knew that we should find a ventilator before ever we came to Stoke
+Moran.”
+
+“My dear Holmes!”
+
+“Oh yes, I did. You remember in her statement she said that her sister
+could smell Dr. Roylott’s cigar. Now, of course that suggested at once
+that there must be a communication between the two rooms. It could only
+be a small one, or it would have been remarked upon at the coroner’s
+inquiry. I deduced a ventilator.”
+
+“But what harm can there be in that?”
+
+“Well, there is at least a curious coincidence of dates. A ventilator
+is made, a cord is hung, and a lady who sleeps in the bed dies. Does
+not that strike you?”
+
+“I cannot as yet see any connection.”
+
+“Did you observe anything very peculiar about that bed?”
+
+“No.”
+
+“It was clamped to the floor. Did you ever see a bed fastened like that
+before?”
+
+“I cannot say that I have.”
+
+“The lady could not move her bed. It must always be in the same
+relative position to the ventilator and to the rope—for so we may call
+it, since it was clearly never meant for a bell-pull.”
+
+“Holmes,” I cried, “I seem to see dimly what you are hinting at. We are
+only just in time to prevent some subtle and horrible crime.”
+
+“Subtle enough and horrible enough. When a doctor does go wrong, he is
+the first of criminals. He has nerve and he has knowledge. Palmer and
+Pritchard were among the heads of their profession. This man strikes
+even deeper, but I think, Watson, that we shall be able to strike
+deeper still. But we shall have horrors enough before the night is
+over; for goodness’ sake let us have a quiet pipe, and turn our minds
+for a few hours to something more cheerful.”
+
+       *       *       *       *       *
+
+About nine o’clock the light among the trees was extinguished, and all
+was dark in the direction of the Manor House. Two hours passed slowly
+away, and then, suddenly, just at the stroke of eleven, a single
+bright light shone out right in front of us.
+
+“That is our signal,” said Holmes, springing to his feet; “it comes
+from the middle window.”
+
+As we passed out he exchanged a few words with the landlord, explaining
+that we were going on a late visit to an acquaintance, and that it was
+possible that we might spend the night there. A moment later we were
+out on the dark road, a chill wind blowing in our faces, and one yellow
+light twinkling in front of us through the gloom to guide us on our
+sombre errand.
+
+There was little difficulty in entering the grounds, for unrepaired
+breaches gaped in the old park wall. Making our way among the trees,
+we reached the lawn, crossed it, and were about to enter through the
+window, when out from a clump of laurel bushes there darted what seemed
+to be a hideous and distorted child, who threw itself upon the grass
+with writhing limbs, and then ran swiftly across the lawn into the
+darkness.
+
+“My God!” I whispered; “did you see it?”
+
+Holmes was for the moment as startled as I. His hand closed like a vice
+upon my wrist in his agitation. Then he broke into a low laugh, and put
+his lips to my ear.
+
+“It is a nice household,” he murmured. “That is the baboon.”
+
+I had forgotten the strange pets which the doctor affected. There was
+a cheetah, too; perhaps we might find it upon our shoulders at any
+moment. I confess that I felt easier in my mind when, after following
+Holmes’s example and slipping off my shoes, I found myself inside the
+bedroom. My companion noiselessly closed the shutters, moved the lamp
+onto the table, and cast his eyes round the room. All was as we had
+seen it in the daytime. Then creeping up to me and making a trumpet of
+his hand, he whispered into my ear again so gently that it was all that
+I could do to distinguish the words:
+
+“The least sound would be fatal to our plans.”
+
+I nodded to show that I had heard.
+
+“We must sit without light. He would see it through the ventilator.”
+
+I nodded again.
+
+“Do not go asleep; your very life may depend upon it. Have your pistol
+ready in case we should need it. I will sit on the side of the bed, and
+you in that chair.”
+
+I took out my revolver and laid it on the corner of the table.
+
+Holmes had brought up a long thin cane, and this he placed upon the bed
+beside him. By it he laid the box of matches and the stump of a candle.
+Then he turned down the lamp, and we were left in darkness.
+
+How shall I ever forget that dreadful vigil? I could not hear a sound,
+not even the drawing of a breath, and yet I knew that my companion
+sat open-eyed, within a few feet of me, in the same state of nervous
+tension in which I was myself. The shutters cut off the least ray
+of light, and we waited in absolute darkness. From outside came the
+occasional cry of a night-bird, and once at our very window a long
+drawn cat-like whine, which told us that the cheetah was indeed at
+liberty. Far away we could hear the deep tones of the parish clock,
+which boomed out every quarter of an hour. How long they seemed, those
+quarters! Twelve struck, and one and two and three, and still we sat
+waiting silently for whatever might befall.
+
+Suddenly there was the momentary gleam of a light up in the direction
+of the ventilator, which vanished immediately, but was succeeded by
+a strong smell of burning oil and heated metal. Some one in the next
+room had lit a dark-lantern. I heard a gentle sound of movement, and
+then all was silent once more, though the smell grew stronger. For half
+an hour I sat with straining ears. Then suddenly another sound became
+audible—a very gentle, soothing sound, like that of a small jet of
+steam escaping continually from a kettle. The instant that we heard it,
+Holmes sprang from the bed, struck a match, and lashed furiously with
+his cane at the bell-pull.
+
+“You see it, Watson?” he yelled. “You see it?”
+
+But I saw nothing. At the moment when Holmes struck the light I heard
+a low, clear whistle, but the sudden glare flashing into my weary eyes
+made it impossible for me to tell what it was at which my friend lashed
+so savagely. I could, however, see that his face was deadly pale, and
+filled with horror and loathing.
+
+He had ceased to strike, and was gazing up at the ventilator, when
+suddenly there broke from the silence of the night the most horrible
+cry to which I have ever listened. It swelled up louder and louder, a
+hoarse yell of pain and fear and anger all mingled in the one dreadful
+shriek. They say that away down in the village, and even in the distant
+parsonage, that cry raised the sleepers from their beds. It struck cold
+to our hearts, and I stood gazing at Holmes, and he at me, until the
+last echoes of it had died away into the silence from which it rose.
+
+“What can it mean?” I gasped.
+
+“It means that it is all over,” Holmes answered. “And perhaps, after
+all, it is for the best. Take your pistol, and we will enter Dr.
+Roylott’s room.”
+
+With a grave face he lit the lamp and led the way down the corridor.
+Twice he struck at the chamber door without any reply from within.
+Then he turned the handle and entered, I at his heels, with the cocked
+pistol in my hand.
+
+It was a singular sight which met our eyes. On the table stood a
+dark-lantern with the shutter half open, throwing a brilliant beam
+of light upon the iron safe, the door of which was ajar. Beside this
+table, on the wooden chair, sat Dr. Grimesby Roylott, clad in a long
+gray dressing-gown, his bare ankles protruding beneath, and his feet
+thrust into red heelless Turkish slippers. Across his lap lay the short
+stock with the long lash which we had noticed during the day. His chin
+was cocked upward and his eyes were fixed in a dreadful, rigid stare
+at the corner of the ceiling. Round his brow he had a peculiar yellow
+band, with brownish speckles, which seemed to be bound tightly round
+his head. As we entered he made neither sound nor motion.
+
+“The band! the speckled band!” whispered Holmes.
+
+I took a step forward. In an instant his strange head-gear began
+to move, and there reared itself from among his hair the squat
+diamond-shaped head and puffed neck of a loathsome serpent.
+
+“It is a swamp adder!” cried Holmes; “the deadliest snake in India. He
+has died within ten seconds of being bitten. Violence does, in truth,
+recoil upon the violent, and the schemer falls into the pit which he
+digs for another. Let us thrust this creature back into its den, and
+we can then remove Miss Stoner to some place of shelter, and let the
+county police know what has happened.”
+
+As he spoke he drew the dog-whip swiftly from the dead man’s lap, and
+throwing the noose round the reptile’s neck, he drew it from its horrid
+perch, and carrying it at arm’s length, threw it into the iron safe,
+which he closed upon it.
+
+       *       *       *       *       *
+
+Such are the true facts of the death of Dr. Grimesby Roylott, of Stoke
+Moran. It is not necessary that I should prolong a narrative which has
+already run to too great a length, by telling how we broke the sad news
+to the terrified girl, how we conveyed her by the morning train to the
+care of her good aunt at Harrow, of how the slow process of official
+inquiry came to the conclusion that the doctor met his fate while
+indiscreetly playing with a dangerous pet. The little which I had yet
+to learn of the case was told me by Sherlock Holmes as we travelled
+back next day.
+
+“I had,” said he, “come to an entirely erroneous conclusion, which
+shows, my dear Watson, how dangerous it always is to reason from
+insufficient data. The presence of the gypsies, and the use of the
+word ‘band,’ which was used by the poor girl, no doubt to explain the
+appearance which she had caught a hurried glimpse of by the light of
+her match, were sufficient to put me upon an entirely wrong scent. I
+can only claim the merit that I instantly reconsidered my position
+when, however, it became clear to me that whatever danger threatened
+an occupant of the room could not come either from the window or the
+door. My attention was speedily drawn, as I have already remarked to
+you, to this ventilator, and to the bell-rope which hung down to the
+bed. The discovery that this was a dummy, and that the bed was clamped
+to the floor, instantly gave rise to the suspicion that the rope was
+there as bridge for something passing through the hole, and coming
+to the bed. The idea of a snake instantly occurred to me, and when
+I coupled it with my knowledge that the doctor was furnished with a
+supply of creatures from India, I felt that I was probably on the right
+track. The idea of using a form of poison which could not possibly be
+discovered by any chemical test was just such a one as would occur to a
+clever and ruthless man who had had an Eastern training. The rapidity
+with which such a poison would take effect would also, from his point
+of view, be an advantage. It would be a sharp-eyed coroner, indeed, who
+could distinguish the two little dark punctures which would show where
+the poison fangs had done their work. Then I thought of the whistle. Of
+course he must recall the snake before the morning light revealed it to
+the victim. He had trained it, probably by the use of the milk which
+we saw, to return to him when summoned. He would put it through this
+ventilator at the hour that he thought best, with the certainty that it
+would crawl down the rope and land on the bed. It might or might not
+bite the occupant, perhaps she might escape every night for a week, but
+sooner or later she must fall a victim.
+
+“I had come to these conclusions before ever I had entered his room.
+An inspection of his chair showed me that he had been in the habit of
+standing on it, which of course would be necessary in order that he
+should reach the ventilator. The sight of the safe, the saucer of milk,
+and the loop of whip-cord were enough to finally dispel any doubts
+which may have remained. The metallic clang heard by Miss Stoner was
+obviously caused by her step-father hastily closing the door of his
+safe upon its terrible occupant. Having once made up my mind, you know
+the steps which I took in order to put the matter to the proof. I
+heard the creature hiss, as I have no doubt that you did also, and I
+instantly lit the light and attacked it.”
+
+“With the result of driving it through the ventilator.”
+
+“And also with the result of causing it to turn upon its master at the
+other side. Some of the blows of my cane came home, and roused its
+snakish temper, so that it flew upon the first person it saw. In this
+way I am no doubt indirectly responsible for Dr. Grimesby Roylott’s
+death, and I cannot say that it is likely to weigh very heavily upon my
+conscience.”

--- a/examples/test/test2/Silver Blaze.txt
+++ b/examples/test/test2/Silver Blaze.txt
@@ -1,0 +1,1159 @@
+Silver Blaze
+
+
+I am afraid, Watson, that I shall have to go,” said Holmes, as we
+sat down together to our breakfast one morning.
+
+“Go! Where to?”
+
+“To Dartmoor; to King’s Pyland.”
+
+I was not surprised. Indeed, my only wonder was that he had not
+already been mixed up in this extraordinary case, which was the
+one topic of conversation through the length and breadth of
+England. For a whole day my companion had rambled about the room
+with his chin upon his chest and his brows knitted, charging and
+recharging his pipe with the strongest black tobacco, and
+absolutely deaf to any of my questions or remarks. Fresh editions
+of every paper had been sent up by our news agent, only to be
+glanced over and tossed down into a corner. Yet, silent as he
+was, I knew perfectly well what it was over which he was
+brooding. There was but one problem before the public which could
+challenge his powers of analysis, and that was the singular
+disappearance of the favourite for the Wessex Cup, and the tragic
+murder of its trainer. When, therefore, he suddenly announced his
+intention of setting out for the scene of the drama it was only
+what I had both expected and hoped for.
+
+“I should be most happy to go down with you if I should not be in
+the way,” said I.
+
+“My dear Watson, you would confer a great favour upon me by
+coming. And I think that your time will not be misspent, for
+there are points about the case which promise to make it an
+absolutely unique one. We have, I think, just time to catch our
+train at Paddington, and I will go further into the matter upon
+our journey. You would oblige me by bringing with you your very
+excellent field-glass.”
+
+And so it happened that an hour or so later I found myself in the
+corner of a first-class carriage flying along en route for
+Exeter, while Sherlock Holmes, with his sharp, eager face framed
+in his ear-flapped travelling-cap, dipped rapidly into the bundle
+of fresh papers which he had procured at Paddington. We had left
+Reading far behind us before he thrust the last one of them under
+the seat, and offered me his cigar-case.
+
+“We are going well,” said he, looking out the window and glancing
+at his watch. “Our rate at present is fifty-three and a half
+miles an hour.”
+
+“I have not observed the quarter-mile posts,” said I.
+
+“Nor have I. But the telegraph posts upon this line are sixty
+yards apart, and the calculation is a simple one. I presume that
+you have looked into this matter of the murder of John Straker
+and the disappearance of Silver Blaze?”
+
+“I have seen what the _Telegraph_ and the _Chronicle_ have to
+say.”
+
+“It is one of those cases where the art of the reasoner should be
+used rather for the sifting of details than for the acquiring of
+fresh evidence. The tragedy has been so uncommon, so complete and
+of such personal importance to so many people, that we are
+suffering from a plethora of surmise, conjecture, and hypothesis.
+The difficulty is to detach the framework of fact—of absolute
+undeniable fact—from the embellishments of theorists and
+reporters. Then, having established ourselves upon this sound
+basis, it is our duty to see what inferences may be drawn and
+what are the special points upon which the whole mystery turns.
+On Tuesday evening I received telegrams from both Colonel Ross,
+the owner of the horse, and from Inspector Gregory, who is
+looking after the case, inviting my co-operation.”
+
+“Tuesday evening!” I exclaimed. “And this is Thursday morning.
+Why didn’t you go down yesterday?”
+
+“Because I made a blunder, my dear Watson—which is, I am afraid,
+a more common occurrence than any one would think who only knew
+me through your memoirs. The fact is that I could not believe it
+possible that the most remarkable horse in England could long
+remain concealed, especially in so sparsely inhabited a place as
+the north of Dartmoor. From hour to hour yesterday I expected to
+hear that he had been found, and that his abductor was the
+murderer of John Straker. When, however, another morning had
+come, and I found that beyond the arrest of young Fitzroy Simpson
+nothing had been done, I felt that it was time for me to take
+action. Yet in some ways I feel that yesterday has not been
+wasted.”
+
+“You have formed a theory, then?”
+
+“At least I have got a grip of the essential facts of the case. I
+shall enumerate them to you, for nothing clears up a case so much
+as stating it to another person, and I can hardly expect your
+co-operation if I do not show you the position from which we
+start.”
+
+I lay back against the cushions, puffing at my cigar, while
+Holmes, leaning forward, with his long, thin forefinger checking
+off the points upon the palm of his left hand, gave me a sketch
+of the events which had led to our journey.
+
+“Silver Blaze,” said he, “is from the Isonomy stock, and holds as
+brilliant a record as his famous ancestor. He is now in his fifth
+year, and has brought in turn each of the prizes of the turf to
+Colonel Ross, his fortunate owner. Up to the time of the
+catastrophe he was the first favourite for the Wessex Cup, the
+betting being three to one on him. He has always, however, been a
+prime favourite with the racing public, and has never yet
+disappointed them, so that even at those odds enormous sums of
+money have been laid upon him. It is obvious, therefore, that
+there were many people who had the strongest interest in
+preventing Silver Blaze from being there at the fall of the flag
+next Tuesday.
+
+“The fact was, of course, appreciated at King’s Pyland, where the
+Colonel’s training-stable is situated. Every precaution was taken
+to guard the favourite. The trainer, John Straker, is a retired
+jockey who rode in Colonel Ross’s colours before he became too
+heavy for the weighing-chair. He has served the Colonel for five
+years as jockey and for seven as trainer, and has always shown
+himself to be a zealous and honest servant. Under him were three
+lads; for the establishment was a small one, containing only four
+horses in all. One of these lads sat up each night in the stable,
+while the others slept in the loft. All three bore excellent
+characters. John Straker, who is a married man, lived in a small
+villa about two hundred yards from the stables. He has no
+children, keeps one maid-servant, and is comfortably off. The
+country round is very lonely, but about half a mile to the north
+there is a small cluster of villas which have been built by a
+Tavistock contractor for the use of invalids and others who may
+wish to enjoy the pure Dartmoor air. Tavistock itself lies two
+miles to the west, while across the moor, also about two miles
+distant, is the larger training establishment of Mapleton, which
+belongs to Lord Backwater, and is managed by Silas Brown. In
+every other direction the moor is a complete wilderness,
+inhabited only by a few roaming gypsies. Such was the general
+situation last Monday night when the catastrophe occurred.
+
+“On that evening the horses had been exercised and watered as
+usual, and the stables were locked up at nine o’clock. Two of the
+lads walked up to the trainer’s house, where they had supper in
+the kitchen, while the third, Ned Hunter, remained on guard. At a
+few minutes after nine the maid, Edith Baxter, carried down to
+the stables his supper, which consisted of a dish of curried
+mutton. She took no liquid, as there was a water-tap in the
+stables, and it was the rule that the lad on duty should drink
+nothing else. The maid carried a lantern with her, as it was very
+dark and the path ran across the open moor.
+
+“Edith Baxter was within thirty yards of the stables, when a man
+appeared out of the darkness and called to her to stop. As he
+stepped into the circle of yellow light thrown by the lantern she
+saw that he was a person of gentlemanly bearing, dressed in a
+grey suit of tweeds, with a cloth cap. He wore gaiters, and
+carried a heavy stick with a knob to it. She was most impressed,
+however, by the extreme pallor of his face and by the nervousness
+of his manner. His age, she thought, would be rather over thirty
+than under it.
+
+“‘Can you tell me where I am?’ he asked. ‘I had almost made up my
+mind to sleep on the moor, when I saw the light of your lantern.’
+
+“‘You are close to the King’s Pyland training-stables,’ said she.
+
+“‘Oh, indeed! What a stroke of luck!’ he cried. ‘I understand
+that a stable-boy sleeps there alone every night. Perhaps that is
+his supper which you are carrying to him. Now I am sure that you
+would not be too proud to earn the price of a new dress, would
+you?’ He took a piece of white paper folded up out of his
+waistcoat pocket. ‘See that the boy has this to-night, and you
+shall have the prettiest frock that money can buy.’
+
+“She was frightened by the earnestness of his manner, and ran
+past him to the window through which she was accustomed to hand
+the meals. It was already opened, and Hunter was seated at the
+small table inside. She had begun to tell him of what had
+happened, when the stranger came up again.
+
+“‘Good-evening,’ said he, looking through the window. ‘I wanted
+to have a word with you.’ The girl has sworn that as he spoke she
+noticed the corner of the little paper packet protruding from his
+closed hand.
+
+“‘What business have you here?’ asked the lad.
+
+“‘It’s business that may put something into your pocket,’ said
+the other. ‘You’ve two horses in for the Wessex Cup—Silver Blaze
+and Bayard. Let me have the straight tip and you won’t be a
+loser. Is it a fact that at the weights Bayard could give the
+other a hundred yards in five furlongs, and that the stable have
+put their money on him?’
+
+“‘So, you’re one of those damned touts!’ cried the lad. ‘I’ll
+show you how we serve them in King’s Pyland.’ He sprang up and
+rushed across the stable to unloose the dog. The girl fled away
+to the house, but as she ran she looked back and saw that the
+stranger was leaning through the window. A minute later, however,
+when Hunter rushed out with the hound he was gone, and though he
+ran all round the buildings he failed to find any trace of him.”
+
+“One moment,” I asked. “Did the stable-boy, when he ran out with
+the dog, leave the door unlocked behind him?”
+
+“Excellent, Watson, excellent!” murmured my companion. “The
+importance of the point struck me so forcibly that I sent a
+special wire to Dartmoor yesterday to clear the matter up. The
+boy locked the door before he left it. The window, I may add, was
+not large enough for a man to get through.
+
+“Hunter waited until his fellow-grooms had returned, when he sent
+a message to the trainer and told him what had occurred. Straker
+was excited at hearing the account, although he does not seem to
+have quite realized its true significance. It left him, however,
+vaguely uneasy, and Mrs. Straker, waking at one in the morning,
+found that he was dressing. In reply to her inquiries, he said
+that he could not sleep on account of his anxiety about the
+horses, and that he intended to walk down to the stables to see
+that all was well. She begged him to remain at home, as she could
+hear the rain pattering against the window, but in spite of her
+entreaties he pulled on his large mackintosh and left the house.
+
+“Mrs. Straker awoke at seven in the morning, to find that her
+husband had not yet returned. She dressed herself hastily, called
+the maid, and set off for the stables. The door was open; inside,
+huddled together upon a chair, Hunter was sunk in a state of
+absolute stupor, the favourite’s stall was empty, and there were
+no signs of his trainer.
+
+“The two lads who slept in the chaff-cutting loft above the
+harness-room were quickly aroused. They had heard nothing during
+the night, for they are both sound sleepers. Hunter was obviously
+under the influence of some powerful drug, and as no sense could
+be got out of him, he was left to sleep it off while the two lads
+and the two women ran out in search of the absentees. They still
+had hopes that the trainer had for some reason taken out the
+horse for early exercise, but on ascending the knoll near the
+house, from which all the neighbouring moors were visible, they
+not only could see no signs of the missing favourite, but they
+perceived something which warned them that they were in the
+presence of a tragedy.
+
+“About a quarter of a mile from the stables John Straker’s
+overcoat was flapping from a furze-bush. Immediately beyond there
+was a bowl-shaped depression in the moor, and at the bottom of
+this was found the dead body of the unfortunate trainer. His head
+had been shattered by a savage blow from some heavy weapon, and
+he was wounded on the thigh, where there was a long, clean cut,
+inflicted evidently by some very sharp instrument. It was clear,
+however, that Straker had defended himself vigorously against his
+assailants, for in his right hand he held a small knife, which
+was clotted with blood up to the handle, while in his left he
+clasped a red and black silk cravat, which was recognised by the
+maid as having been worn on the preceding evening by the stranger
+who had visited the stables.
+
+“Hunter, on recovering from his stupor, was also quite positive
+as to the ownership of the cravat. He was equally certain that
+the same stranger had, while standing at the window, drugged his
+curried mutton, and so deprived the stables of their watchman.
+
+“As to the missing horse, there were abundant proofs in the mud
+which lay at the bottom of the fatal hollow that he had been
+there at the time of the struggle. But from that morning he has
+disappeared, and although a large reward has been offered, and
+all the gypsies of Dartmoor are on the alert, no news has come of
+him. Finally, an analysis has shown that the remains of his
+supper left by the stable-lad contain an appreciable quantity of
+powdered opium, while the people at the house partook of the same
+dish on the same night without any ill effect.
+
+“Those are the main facts of the case, stripped of all surmise,
+and stated as baldly as possible. I shall now recapitulate what
+the police have done in the matter.
+
+“Inspector Gregory, to whom the case has been committed, is an
+extremely competent officer. Were he but gifted with imagination
+he might rise to great heights in his profession. On his arrival
+he promptly found and arrested the man upon whom suspicion
+naturally rested. There was little difficulty in finding him, for
+he inhabited one of those villas which I have mentioned. His
+name, it appears, was Fitzroy Simpson. He was a man of excellent
+birth and education, who had squandered a fortune upon the turf,
+and who lived now by doing a little quiet and genteel book-making
+in the sporting clubs of London. An examination of his
+betting-book shows that bets to the amount of five thousand
+pounds had been registered by him against the favourite.
+
+“On being arrested he volunteered the statement that he had come
+down to Dartmoor in the hope of getting some information about
+the King’s Pyland horses, and also about Desborough, the second
+favourite, which was in charge of Silas Brown at the Mapleton
+stables. He did not attempt to deny that he had acted as
+described upon the evening before, but declared that he had no
+sinister designs, and had simply wished to obtain first-hand
+information. When confronted with his cravat, he turned very
+pale, and was utterly unable to account for its presence in the
+hand of the murdered man. His wet clothing showed that he had
+been out in the storm of the night before, and his stick, which
+was a Penang-lawyer weighted with lead, was just such a weapon as
+might, by repeated blows, have inflicted the terrible injuries to
+which the trainer had succumbed.
+
+“On the other hand, there was no wound upon his person, while the
+state of Straker’s knife would show that one at least of his
+assailants must bear his mark upon him. There you have it all in
+a nutshell, Watson, and if you can give me any light I shall be
+infinitely obliged to you.”
+
+I had listened with the greatest interest to the statement which
+Holmes, with characteristic clearness, had laid before me. Though
+most of the facts were familiar to me, I had not sufficiently
+appreciated their relative importance, nor their connection to
+each other.
+
+“Is it not possible,” I suggested, “that the incised wound upon
+Straker may have been caused by his own knife in the convulsive
+struggles which follow any brain injury?”
+
+“It is more than possible; it is probable,” said Holmes. “In that
+case one of the main points in favour of the accused disappears.”
+
+“And yet,” said I, “even now I fail to understand what the theory
+of the police can be.”
+
+“I am afraid that whatever theory we state has very grave
+objections to it,” returned my companion. “The police imagine, I
+take it, that this Fitzroy Simpson, having drugged the lad, and
+having in some way obtained a duplicate key, opened the stable
+door and took out the horse, with the intention, apparently, of
+kidnapping him altogether. His bridle is missing, so that Simpson
+must have put this on. Then, having left the door open behind
+him, he was leading the horse away over the moor, when he was
+either met or overtaken by the trainer. A row naturally ensued.
+Simpson beat out the trainer’s brains with his heavy stick
+without receiving any injury from the small knife which Straker
+used in self-defence, and then the thief either led the horse on
+to some secret hiding-place, or else it may have bolted during
+the struggle, and be now wandering out on the moors. That is the
+case as it appears to the police, and improbable as it is, all
+other explanations are more improbable still. However, I shall
+very quickly test the matter when I am once upon the spot, and
+until then I cannot really see how we can get much further than
+our present position.”
+
+It was evening before we reached the little town of Tavistock,
+which lies, like the boss of a shield, in the middle of the huge
+circle of Dartmoor. Two gentlemen were awaiting us in the
+station—the one a tall, fair man with lion-like hair and beard
+and curiously penetrating light blue eyes; the other a small,
+alert person, very neat and dapper, in a frock-coat and gaiters,
+with trim little side-whiskers and an eye-glass. The latter was
+Colonel Ross, the well-known sportsman; the other, Inspector
+Gregory, a man who was rapidly making his name in the English
+detective service.
+
+“I am delighted that you have come down, Mr. Holmes,” said the
+Colonel. “The Inspector here has done all that could possibly be
+suggested, but I wish to leave no stone unturned in trying to
+avenge poor Straker and in recovering my horse.”
+
+“Have there been any fresh developments?” asked Holmes.
+
+“I am sorry to say that we have made very little progress,” said
+the Inspector. “We have an open carriage outside, and as you
+would no doubt like to see the place before the light fails, we
+might talk it over as we drive.”
+
+A minute later we were all seated in a comfortable landau, and
+were rattling through the quaint old Devonshire city. Inspector
+Gregory was full of his case, and poured out a stream of remarks,
+while Holmes threw in an occasional question or interjection.
+Colonel Ross leaned back with his arms folded and his hat tilted
+over his eyes, while I listened with interest to the dialogue of
+the two detectives. Gregory was formulating his theory, which was
+almost exactly what Holmes had foretold in the train.
+
+“The net is drawn pretty close round Fitzroy Simpson,” he
+remarked, “and I believe myself that he is our man. At the same
+time I recognise that the evidence is purely circumstantial, and
+that some new development may upset it.”
+
+“How about Straker’s knife?”
+
+“We have quite come to the conclusion that he wounded himself in
+his fall.”
+
+“My friend Dr. Watson made that suggestion to me as we came down.
+If so, it would tell against this man Simpson.”
+
+“Undoubtedly. He has neither a knife nor any sign of a wound. The
+evidence against him is certainly very strong. He had a great
+interest in the disappearance of the favourite. He lies under
+suspicion of having poisoned the stable-boy, he was undoubtedly
+out in the storm, he was armed with a heavy stick, and his cravat
+was found in the dead man’s hand. I really think we have enough
+to go before a jury.”
+
+Holmes shook his head. “A clever counsel would tear it all to
+rags,” said he. “Why should he take the horse out of the stable?
+If he wished to injure it why could he not do it there? Has a
+duplicate key been found in his possession? What chemist sold him
+the powdered opium? Above all, where could he, a stranger to the
+district, hide a horse, and such a horse as this? What is his own
+explanation as to the paper which he wished the maid to give to
+the stable-boy?”
+
+“He says that it was a ten-pound note. One was found in his
+purse. But your other difficulties are not so formidable as they
+seem. He is not a stranger to the district. He has twice lodged
+at Tavistock in the summer. The opium was probably brought from
+London. The key, having served its purpose, would be hurled away.
+The horse may be at the bottom of one of the pits or old mines
+upon the moor.”
+
+“What does he say about the cravat?”
+
+“He acknowledges that it is his, and declares that he had lost
+it. But a new element has been introduced into the case which may
+account for his leading the horse from the stable.”
+
+Holmes pricked up his ears.
+
+“We have found traces which show that a party of gypsies encamped
+on Monday night within a mile of the spot where the murder took
+place. On Tuesday they were gone. Now, presuming that there was
+some understanding between Simpson and these gypsies, might he
+not have been leading the horse to them when he was overtaken,
+and may they not have him now?”
+
+“It is certainly possible.”
+
+“The moor is being scoured for these gypsies. I have also
+examined every stable and out-house in Tavistock, and for a
+radius of ten miles.”
+
+“There is another training-stable quite close, I understand?”
+
+“Yes, and that is a factor which we must certainly not neglect.
+As Desborough, their horse, was second in the betting, they had
+an interest in the disappearance of the favourite. Silas Brown,
+the trainer, is known to have had large bets upon the event, and
+he was no friend to poor Straker. We have, however, examined the
+stables, and there is nothing to connect him with the affair.”
+
+“And nothing to connect this man Simpson with the interests of
+the Mapleton stables?”
+
+“Nothing at all.”
+
+Holmes leaned back in the carriage, and the conversation ceased.
+A few minutes later our driver pulled up at a neat little
+red-brick villa with overhanging eaves which stood by the road.
+Some distance off, across a paddock, lay a long grey-tiled
+out-building. In every other direction the low curves of the
+moor, bronze-coloured from the fading ferns, stretched away to
+the sky-line, broken only by the steeples of Tavistock, and by a
+cluster of houses away to the westward which marked the Mapleton
+stables. We all sprang out with the exception of Holmes, who
+continued to lean back with his eyes fixed upon the sky in front
+of him, entirely absorbed in his own thoughts. It was only when I
+touched his arm that he roused himself with a violent start and
+stepped out of the carriage.
+
+“Excuse me,” said he, turning to Colonel Ross, who had looked at
+him in some surprise. “I was day-dreaming.” There was a gleam in
+his eyes and a suppressed excitement in his manner which
+convinced me, used as I was to his ways, that his hand was upon a
+clue, though I could not imagine where he had found it.
+
+“Perhaps you would prefer at once to go on to the scene of the
+crime, Mr. Holmes?” said Gregory.
+
+“I think that I should prefer to stay here a little and go into
+one or two questions of detail. Straker was brought back here, I
+presume?”
+
+“Yes; he lies upstairs. The inquest is to-morrow.”
+
+“He has been in your service some years, Colonel Ross?”
+
+“I have always found him an excellent servant.”
+
+“I presume that you made an inventory of what he had in his
+pockets at the time of his death, Inspector?”
+
+“I have the things themselves in the sitting-room, if you would
+care to see them.”
+
+“I should be very glad.” We all filed into the front room and sat
+round the central table while the Inspector unlocked a square tin
+box and laid a small heap of things before us. There was a box of
+vestas, two inches of tallow candle, an A.D.P. briar-root pipe, a
+pouch of seal-skin with half an ounce of long-cut Cavendish, a
+silver watch with a gold chain, five sovereigns in gold, an
+aluminium pencil-case, a few papers, and an ivory-handled knife
+with a very delicate, inflexible blade marked Weiss & Co.,
+London.
+
+“This is a very singular knife,” said Holmes, lifting it up and
+examining it minutely. “I presume, as I see blood-stains upon it,
+that it is the one which was found in the dead man’s grasp.
+Watson, this knife is surely in your line?”
+
+“It is what we call a cataract knife,” said I.
+
+“I thought so. A very delicate blade devised for very delicate
+work. A strange thing for a man to carry with him upon a rough
+expedition, especially as it would not shut in his pocket.”
+
+“The tip was guarded by a disk of cork which we found beside his
+body,” said the Inspector. “His wife tells us that the knife had
+lain upon the dressing-table, and that he had picked it up as he
+left the room. It was a poor weapon, but perhaps the best that he
+could lay his hands on at the moment.”
+
+“Very possible. How about these papers?”
+
+“Three of them are receipted hay-dealers’ accounts. One of them
+is a letter of instructions from Colonel Ross. This other is a
+milliner’s account for thirty-seven pounds fifteen made out by
+Madame Lesurier, of Bond Street, to William Derbyshire. Mrs.
+Straker tells us that Derbyshire was a friend of her husband’s
+and that occasionally his letters were addressed here.”
+
+“Madam Derbyshire had somewhat expensive tastes,” remarked
+Holmes, glancing down the account. “Twenty-two guineas is rather
+heavy for a single costume. However there appears to be nothing
+more to learn, and we may now go down to the scene of the crime.”
+
+As we emerged from the sitting-room a woman, who had been waiting
+in the passage, took a step forward and laid her hand upon the
+Inspector’s sleeve. Her face was haggard and thin and eager,
+stamped with the print of a recent horror.
+
+“Have you got them? Have you found them?” she panted.
+
+“No, Mrs. Straker. But Mr. Holmes here has come from London to
+help us, and we shall do all that is possible.”
+
+“Surely I met you in Plymouth at a garden-party some little time
+ago, Mrs. Straker?” said Holmes.
+
+“No, sir; you are mistaken.”
+
+“Dear me! Why, I could have sworn to it. You wore a costume of
+dove-coloured silk with ostrich-feather trimming.”
+
+“I never had such a dress, sir,” answered the lady.
+
+“Ah, that quite settles it,” said Holmes. And with an apology he
+followed the Inspector outside. A short walk across the moor took
+us to the hollow in which the body had been found. At the brink
+of it was the furze-bush upon which the coat had been hung.
+
+“There was no wind that night, I understand,” said Holmes.
+
+“None; but very heavy rain.”
+
+“In that case the overcoat was not blown against the furze-bush,
+but placed there.”
+
+“Yes, it was laid across the bush.”
+
+“You fill me with interest, I perceive that the ground has been
+trampled up a good deal. No doubt many feet have been here since
+Monday night.”
+
+“A piece of matting has been laid here at the side, and we have
+all stood upon that.”
+
+“Excellent.”
+
+“In this bag I have one of the boots which Straker wore, one of
+Fitzroy Simpson’s shoes, and a cast horseshoe of Silver Blaze.”
+
+“My dear Inspector, you surpass yourself!” Holmes took the bag,
+and, descending into the hollow, he pushed the matting into a
+more central position. Then stretching himself upon his face and
+leaning his chin upon his hands, he made a careful study of the
+trampled mud in front of him. “Hullo!” said he, suddenly. “What’s
+this?” It was a wax vesta half burned, which was so coated with
+mud that it looked at first like a little chip of wood.
+
+“I cannot think how I came to overlook it,” said the Inspector,
+with an expression of annoyance.
+
+“It was invisible, buried in the mud. I only saw it because I was
+looking for it.”
+
+“What! You expected to find it?”
+
+“I thought it not unlikely.”
+
+He took the boots from the bag, and compared the impressions of
+each of them with marks upon the ground. Then he clambered up to
+the rim of the hollow, and crawled about among the ferns and
+bushes.
+
+“I am afraid that there are no more tracks,” said the Inspector.
+“I have examined the ground very carefully for a hundred yards in
+each direction.”
+
+“Indeed!” said Holmes, rising. “I should not have the
+impertinence to do it again after what you say. But I should like
+to take a little walk over the moor before it grows dark, that I
+may know my ground to-morrow, and I think that I shall put this
+horseshoe into my pocket for luck.”
+
+Colonel Ross, who had shown some signs of impatience at my
+companion’s quiet and systematic method of work, glanced at his
+watch. “I wish you would come back with me, Inspector,” said he.
+“There are several points on which I should like your advice, and
+especially as to whether we do not owe it to the public to remove
+our horse’s name from the entries for the Cup.”
+
+“Certainly not,” cried Holmes, with decision. “I should let the
+name stand.”
+
+The Colonel bowed. “I am very glad to have had your opinion,
+sir,” said he. “You will find us at poor Straker’s house when you
+have finished your walk, and we can drive together into
+Tavistock.”
+
+He turned back with the Inspector, while Holmes and I walked
+slowly across the moor. The sun was beginning to sink behind the
+stables of Mapleton, and the long, sloping plain in front of us
+was tinged with gold, deepening into rich, ruddy browns where the
+faded ferns and brambles caught the evening light. But the
+glories of the landscape were all wasted upon my companion, who
+was sunk in the deepest thought.
+
+“It’s this way, Watson,” said he at last. “We may leave the
+question of who killed John Straker for the instant, and confine
+ourselves to finding out what has become of the horse. Now,
+supposing that he broke away during or after the tragedy, where
+could he have gone to? The horse is a very gregarious creature.
+If left to himself his instincts would have been either to return
+to King’s Pyland or go over to Mapleton. Why should he run wild
+upon the moor? He would surely have been seen by now. And why
+should gypsies kidnap him? These people always clear out when
+they hear of trouble, for they do not wish to be pestered by the
+police. They could not hope to sell such a horse. They would run
+a great risk and gain nothing by taking him. Surely that is
+clear.”
+
+“Where is he, then?”
+
+“I have already said that he must have gone to King’s Pyland or
+to Mapleton. He is not at King’s Pyland. Therefore he is at
+Mapleton. Let us take that as a working hypothesis and see what
+it leads us to. This part of the moor, as the Inspector remarked,
+is very hard and dry. But it falls away towards Mapleton, and you
+can see from here that there is a long hollow over yonder, which
+must have been very wet on Monday night. If our supposition is
+correct, then the horse must have crossed that, and there is the
+point where we should look for his tracks.”
+
+We had been walking briskly during this conversation, and a few
+more minutes brought us to the hollow in question. At Holmes’
+request I walked down the bank to the right, and he to the left,
+but I had not taken fifty paces before I heard him give a shout,
+and saw him waving his hand to me. The track of a horse was
+plainly outlined in the soft earth in front of him, and the shoe
+which he took from his pocket exactly fitted the impression.
+
+“See the value of imagination,” said Holmes. “It is the one
+quality which Gregory lacks. We imagined what might have
+happened, acted upon the supposition, and find ourselves
+justified. Let us proceed.”
+
+We crossed the marshy bottom and passed over a quarter of a mile
+of dry, hard turf. Again the ground sloped, and again we came on
+the tracks. Then we lost them for half a mile, but only to pick
+them up once more quite close to Mapleton. It was Holmes who saw
+them first, and he stood pointing with a look of triumph upon his
+face. A man’s track was visible beside the horse’s.
+
+“The horse was alone before,” I cried.
+
+“Quite so. It was alone before. Hullo, what is this?”
+
+The double track turned sharp off and took the direction of
+King’s Pyland. Holmes whistled, and we both followed along after
+it. His eyes were on the trail, but I happened to look a little
+to one side, and saw to my surprise the same tracks coming back
+again in the opposite direction.
+
+“One for you, Watson,” said Holmes, when I pointed it out. “You
+have saved us a long walk, which would have brought us back on
+our own traces. Let us follow the return track.”
+
+We had not to go far. It ended at the paving of asphalt which led
+up to the gates of the Mapleton stables. As we approached, a
+groom ran out from them.
+
+“We don’t want any loiterers about here,” said he.
+
+“I only wished to ask a question,” said Holmes, with his finger
+and thumb in his waistcoat pocket. “Should I be too early to see
+your master, Mr. Silas Brown, if I were to call at five o’clock
+to-morrow morning?”
+
+“Bless you, sir, if any one is about he will be, for he is always
+the first stirring. But here he is, sir, to answer your questions
+for himself. No, sir, no; it is as much as my place is worth to
+let him see me touch your money. Afterwards, if you like.”
+
+As Sherlock Holmes replaced the half-crown which he had drawn
+from his pocket, a fierce-looking elderly man strode out from the
+gate with a hunting-crop swinging in his hand.
+
+“What’s this, Dawson!” he cried. “No gossiping! Go about your
+business! And you, what the devil do you want here?”
+
+“Ten minutes’ talk with you, my good sir,” said Holmes in the
+sweetest of voices.
+
+“I’ve no time to talk to every gadabout. We want no strangers
+here. Be off, or you may find a dog at your heels.”
+
+Holmes leaned forward and whispered something in the trainer’s
+ear. He started violently and flushed to the temples.
+
+“It’s a lie!” he shouted, “an infernal lie!”
+
+“Very good. Shall we argue about it here in public or talk it
+over in your parlour?”
+
+“Oh, come in if you wish to.”
+
+Holmes smiled. “I shall not keep you more than a few minutes,
+Watson,” said he. “Now, Mr. Brown, I am quite at your disposal.”
+
+It was twenty minutes, and the reds had all faded into greys
+before Holmes and the trainer reappeared. Never have I seen such
+a change as had been brought about in Silas Brown in that short
+time. His face was ashy pale, beads of perspiration shone upon
+his brow, and his hands shook until the hunting-crop wagged like
+a branch in the wind. His bullying, overbearing manner was all
+gone too, and he cringed along at my companion’s side like a dog
+with its master.
+
+“Your instructions will be done. It shall all be done,” said he.
+
+“There must be no mistake,” said Holmes, looking round at him.
+The other winced as he read the menace in his eyes.
+
+“Oh no, there shall be no mistake. It shall be there. Should I
+change it first or not?”
+
+Holmes thought a little and then burst out laughing. “No, don’t,”
+said he; “I shall write to you about it. No tricks, now, or—”
+
+“Oh, you can trust me, you can trust me!”
+
+“Yes, I think I can. Well, you shall hear from me to-morrow.” He
+turned upon his heel, disregarding the trembling hand which the
+other held out to him, and we set off for King’s Pyland.
+
+“A more perfect compound of the bully, coward, and sneak than
+Master Silas Brown I have seldom met with,” remarked Holmes as we
+trudged along together.
+
+“He has the horse, then?”
+
+“He tried to bluster out of it, but I described to him so exactly
+what his actions had been upon that morning that he is convinced
+that I was watching him. Of course you observed the peculiarly
+square toes in the impressions, and that his own boots exactly
+corresponded to them. Again, of course no subordinate would have
+dared to do such a thing. I described to him how, when according
+to his custom he was the first down, he perceived a strange horse
+wandering over the moor. How he went out to it, and his
+astonishment at recognising, from the white forehead which has
+given the favourite its name, that chance had put in his power
+the only horse which could beat the one upon which he had put his
+money. Then I described how his first impulse had been to lead
+him back to King’s Pyland, and how the devil had shown him how he
+could hide the horse until the race was over, and how he had led
+it back and concealed it at Mapleton. When I told him every
+detail he gave it up and thought only of saving his own skin.”
+
+“But his stables had been searched?”
+
+“Oh, an old horse-faker like him has many a dodge.”
+
+“But are you not afraid to leave the horse in his power now,
+since he has every interest in injuring it?”
+
+“My dear fellow, he will guard it as the apple of his eye. He
+knows that his only hope of mercy is to produce it safe.”
+
+“Colonel Ross did not impress me as a man who would be likely to
+show much mercy in any case.”
+
+“The matter does not rest with Colonel Ross. I follow my own
+methods, and tell as much or as little as I choose. That is the
+advantage of being unofficial. I don’t know whether you observed
+it, Watson, but the Colonel’s manner has been just a trifle
+cavalier to me. I am inclined now to have a little amusement at
+his expense. Say nothing to him about the horse.”
+
+“Certainly not without your permission.”
+
+“And of course this is all quite a minor point compared to the
+question of who killed John Straker.”
+
+“And you will devote yourself to that?”
+
+“On the contrary, we both go back to London by the night train.”
+
+I was thunderstruck by my friend’s words. We had only been a few
+hours in Devonshire, and that he should give up an investigation
+which he had begun so brilliantly was quite incomprehensible to
+me. Not a word more could I draw from him until we were back at
+the trainer’s house. The Colonel and the Inspector were awaiting
+us in the parlour.
+
+“My friend and I return to town by the night-express,” said
+Holmes. “We have had a charming little breath of your beautiful
+Dartmoor air.”
+
+The Inspector opened his eyes, and the Colonel’s lip curled in a
+sneer.
+
+“So you despair of arresting the murderer of poor Straker,” said
+he.
+
+Holmes shrugged his shoulders. “There are certainly grave
+difficulties in the way,” said he. “I have every hope, however,
+that your horse will start upon Tuesday, and I beg that you will
+have your jockey in readiness. Might I ask for a photograph of
+Mr. John Straker?”
+
+The Inspector took one from an envelope and handed it to him.
+
+“My dear Gregory, you anticipate all my wants. If I might ask you
+to wait here for an instant, I have a question which I should
+like to put to the maid.”
+
+“I must say that I am rather disappointed in our London
+consultant,” said Colonel Ross, bluntly, as my friend left the
+room. “I do not see that we are any further than when he came.”
+
+“At least you have his assurance that your horse will run,” said
+I.
+
+“Yes, I have his assurance,” said the Colonel, with a shrug of
+his shoulders. “I should prefer to have the horse.”
+
+I was about to make some reply in defence of my friend when he
+entered the room again.
+
+“Now, gentlemen,” said he, “I am quite ready for Tavistock.”
+
+As we stepped into the carriage one of the stable-lads held the
+door open for us. A sudden idea seemed to occur to Holmes, for he
+leaned forward and touched the lad upon the sleeve.
+
+“You have a few sheep in the paddock,” he said. “Who attends to
+them?”
+
+“I do, sir.”
+
+“Have you noticed anything amiss with them of late?”
+
+“Well, sir, not of much account; but three of them have gone
+lame, sir.”
+
+I could see that Holmes was extremely pleased, for he chuckled
+and rubbed his hands together.
+
+“A long shot, Watson; a very long shot,” said he, pinching my
+arm. “Gregory, let me recommend to your attention this singular
+epidemic among the sheep. Drive on, coachman!”
+
+Colonel Ross still wore an expression which showed the poor
+opinion which he had formed of my companion’s ability, but I saw
+by the Inspector’s face that his attention had been keenly
+aroused.
+
+“You consider that to be important?” he asked.
+
+“Exceedingly so.”
+
+“Is there any point to which you would wish to draw my
+attention?”
+
+“To the curious incident of the dog in the night-time.”
+
+“The dog did nothing in the night-time.”
+
+“That was the curious incident,” remarked Sherlock Holmes.
+
+Four days later Holmes and I were again in the train, bound for
+Winchester to see the race for the Wessex Cup. Colonel Ross met
+us by appointment outside the station, and we drove in his drag
+to the course beyond the town. His face was grave, and his manner
+was cold in the extreme.
+
+“I have seen nothing of my horse,” said he.
+
+“I suppose that you would know him when you saw him?” asked
+Holmes.
+
+The Colonel was very angry. “I have been on the turf for twenty
+years, and never was asked such a question as that before,” said
+he. “A child would know Silver Blaze, with his white forehead and
+his mottled off-foreleg.”
+
+“How is the betting?”
+
+“Well, that is the curious part of it. You could have got fifteen
+to one yesterday, but the price has become shorter and shorter,
+until you can hardly get three to one now.”
+
+“Hum!” said Holmes. “Somebody knows something, that is clear.”
+
+As the drag drew up in the enclosure near the grand stand I
+glanced at the card to see the entries. It ran:—
+
+Wessex Plate. 50 sovs each h ft with 1000 sovs added for four and
+five year olds. Second, £300. Third, £200. New course (one mile
+and five furlongs).
+1. Mr. Heath Newton’s The Negro (red cap, cinnamon jacket).
+2. Colonel Wardlaw’s Pugilist (pink cap, blue and black jacket).
+3. Lord Backwater’s Desborough (yellow cap and sleeves).
+4. Colonel Ross’s Silver Blaze (black cap, red jacket).
+5. Duke of Balmoral’s Iris (yellow and black stripes).
+6. Lord Singleford’s Rasper (purple cap, black sleeves).
+
+“We scratched our other one, and put all hopes on your word,”
+said the Colonel. “Why, what is that? Silver Blaze favourite?”
+
+“Five to four against Silver Blaze!” roared the ring. “Five to
+four against Silver Blaze! Five to fifteen against Desborough!
+Five to four on the field!”
+
+“There are the numbers up,” I cried. “They are all six there.”
+
+“All six there? Then my horse is running,” cried the Colonel in
+great agitation. “But I don’t see him. My colours have not
+passed.”
+
+“Only five have passed. This must be he.”
+
+As I spoke a powerful bay horse swept out from the weighing
+enclosure and cantered past us, bearing on its back the
+well-known black and red of the Colonel.
+
+“That’s not my horse,” cried the owner. “That beast has not a
+white hair upon its body. What is this that you have done, Mr.
+Holmes?”
+
+“Well, well, let us see how he gets on,” said my friend,
+imperturbably. For a few minutes he gazed through my field-glass.
+“Capital! An excellent start!” he cried suddenly. “There they
+are, coming round the curve!”
+
+From our drag we had a superb view as they came up the straight.
+The six horses were so close together that a carpet could have
+covered them, but half way up the yellow of the Mapleton stable
+showed to the front. Before they reached us, however,
+Desborough’s bolt was shot, and the Colonel’s horse, coming away
+with a rush, passed the post a good six lengths before its rival,
+the Duke of Balmoral’s Iris making a bad third.
+
+“It’s my race, anyhow,” gasped the Colonel, passing his hand over
+his eyes. “I confess that I can make neither head nor tail of it.
+Don’t you think that you have kept up your mystery long enough,
+Mr. Holmes?”
+
+“Certainly, Colonel, you shall know everything. Let us all go
+round and have a look at the horse together. Here he is,” he
+continued, as we made our way into the weighing enclosure, where
+only owners and their friends find admittance. “You have only to
+wash his face and his leg in spirits of wine, and you will find
+that he is the same old Silver Blaze as ever.”
+
+“You take my breath away!”
+
+“I found him in the hands of a faker, and took the liberty of
+running him just as he was sent over.”
+
+“My dear sir, you have done wonders. The horse looks very fit and
+well. It never went better in its life. I owe you a thousand
+apologies for having doubted your ability. You have done me a
+great service by recovering my horse. You would do me a greater
+still if you could lay your hands on the murderer of John
+Straker.”
+
+“I have done so,” said Holmes quietly.
+
+The Colonel and I stared at him in amazement. “You have got him!
+Where is he, then?”
+
+“He is here.”
+
+“Here! Where?”
+
+“In my company at the present moment.”
+
+The Colonel flushed angrily. “I quite recognise that I am under
+obligations to you, Mr. Holmes,” said he, “but I must regard what
+you have just said as either a very bad joke or an insult.”
+
+Sherlock Holmes laughed. “I assure you that I have not associated
+you with the crime, Colonel,” said he. “The real murderer is
+standing immediately behind you.” He stepped past and laid his
+hand upon the glossy neck of the thoroughbred.
+
+“The horse!” cried both the Colonel and myself.
+
+“Yes, the horse. And it may lessen his guilt if I say that it was
+done in self-defence, and that John Straker was a man who was
+entirely unworthy of your confidence. But there goes the bell,
+and as I stand to win a little on this next race, I shall defer a
+lengthy explanation until a more fitting time.”
+
+We had the corner of a Pullman car to ourselves that evening as
+we whirled back to London, and I fancy that the journey was a
+short one to Colonel Ross as well as to myself, as we listened to
+our companion’s narrative of the events which had occurred at the
+Dartmoor training-stables upon the Monday night, and the means by
+which he had unravelled them.
+
+“I confess,” said he, “that any theories which I had formed from
+the newspaper reports were entirely erroneous. And yet there were
+indications there, had they not been overlaid by other details
+which concealed their true import. I went to Devonshire with the
+conviction that Fitzroy Simpson was the true culprit, although,
+of course, I saw that the evidence against him was by no means
+complete. It was while I was in the carriage, just as we reached
+the trainer’s house, that the immense significance of the curried
+mutton occurred to me. You may remember that I was distrait, and
+remained sitting after you had all alighted. I was marvelling in
+my own mind how I could possibly have overlooked so obvious a
+clue.”
+
+“I confess,” said the Colonel, “that even now I cannot see how it
+helps us.”
+
+“It was the first link in my chain of reasoning. Powdered opium
+is by no means tasteless. The flavour is not disagreeable, but it
+is perceptible. Were it mixed with any ordinary dish the eater
+would undoubtedly detect it, and would probably eat no more. A
+curry was exactly the medium which would disguise this taste. By
+no possible supposition could this stranger, Fitzroy Simpson,
+have caused curry to be served in the trainer’s family that
+night, and it is surely too monstrous a coincidence to suppose
+that he happened to come along with powdered opium upon the very
+night when a dish happened to be served which would disguise the
+flavour. That is unthinkable. Therefore Simpson becomes
+eliminated from the case, and our attention centres upon Straker
+and his wife, the only two people who could have chosen curried
+mutton for supper that night. The opium was added after the dish
+was set aside for the stable-boy, for the others had the same for
+supper with no ill effects. Which of them, then, had access to
+that dish without the maid seeing them?
+
+“Before deciding that question I had grasped the significance of
+the silence of the dog, for one true inference invariably
+suggests others. The Simpson incident had shown me that a dog was
+kept in the stables, and yet, though some one had been in and had
+fetched out a horse, he had not barked enough to arouse the two
+lads in the loft. Obviously the midnight visitor was some one
+whom the dog knew well.
+
+“I was already convinced, or almost convinced, that John Straker
+went down to the stables in the dead of the night and took out
+Silver Blaze. For what purpose? For a dishonest one, obviously,
+or why should he drug his own stable-boy? And yet I was at a loss
+to know why. There have been cases before now where trainers have
+made sure of great sums of money by laying against their own
+horses, through agents, and then preventing them from winning by
+fraud. Sometimes it is a pulling jockey. Sometimes it is some
+surer and subtler means. What was it here? I hoped that the
+contents of his pockets might help me to form a conclusion.
+
+“And they did so. You cannot have forgotten the singular knife
+which was found in the dead man’s hand, a knife which certainly
+no sane man would choose for a weapon. It was, as Dr. Watson told
+us, a form of knife which is used for the most delicate
+operations known in surgery. And it was to be used for a delicate
+operation that night. You must know, with your wide experience of
+turf matters, Colonel Ross, that it is possible to make a slight
+nick upon the tendons of a horse’s ham, and to do it
+subcutaneously, so as to leave absolutely no trace. A horse so
+treated would develop a slight lameness, which would be put down
+to a strain in exercise or a touch of rheumatism, but never to
+foul play.”
+
+“Villain! Scoundrel!” cried the Colonel.
+
+“We have here the explanation of why John Straker wished to take
+the horse out on to the moor. So spirited a creature would have
+certainly roused the soundest of sleepers when it felt the prick
+of the knife. It was absolutely necessary to do it in the open
+air.”
+
+“I have been blind!” cried the Colonel. “Of course that was why
+he needed the candle, and struck the match.”
+
+“Undoubtedly. But in examining his belongings I was fortunate
+enough to discover not only the method of the crime, but even its
+motives. As a man of the world, Colonel, you know that men do not
+carry other people’s bills about in their pockets. We have most
+of us quite enough to do to settle our own. I at once concluded
+that Straker was leading a double life, and keeping a second
+establishment. The nature of the bill showed that there was a
+lady in the case, and one who had expensive tastes. Liberal as
+you are with your servants, one can hardly expect that they can
+buy twenty-guinea walking dresses for their ladies. I questioned
+Mrs. Straker as to the dress without her knowing it, and having
+satisfied myself that it had never reached her, I made a note of
+the milliner’s address, and felt that by calling there with
+Straker’s photograph I could easily dispose of the mythical
+Derbyshire.
+
+“From that time on all was plain. Straker had led out the horse
+to a hollow where his light would be invisible. Simpson in his
+flight had dropped his cravat, and Straker had picked it up—with
+some idea, perhaps, that he might use it in securing the horse’s
+leg. Once in the hollow, he had got behind the horse and had
+struck a light; but the creature frightened at the sudden glare,
+and with the strange instinct of animals feeling that some
+mischief was intended, had lashed out, and the steel shoe had
+struck Straker full on the forehead. He had already, in spite of
+the rain, taken off his overcoat in order to do his delicate
+task, and so, as he fell, his knife gashed his thigh. Do I make
+it clear?”
+
+“Wonderful!” cried the Colonel. “Wonderful! You might have been
+there!”
+
+“My final shot was, I confess a very long one. It struck me that
+so astute a man as Straker would not undertake this delicate
+tendon-nicking without a little practice. What could he practice
+on? My eyes fell upon the sheep, and I asked a question which,
+rather to my surprise, showed that my surmise was correct.
+
+“When I returned to London I called upon the milliner, who had
+recognised Straker as an excellent customer of the name of
+Derbyshire, who had a very dashing wife, with a strong partiality
+for expensive dresses. I have no doubt that this woman had
+plunged him over head and ears in debt, and so led him into this
+miserable plot.”
+
+“You have explained all but one thing,” cried the Colonel. “Where
+was the horse?”
+
+“Ah, it bolted, and was cared for by one of your neighbours. We
+must have an amnesty in that direction, I think. This is Clapham
+Junction, if I am not mistaken, and we shall be in Victoria in
+less than ten minutes. If you care to smoke a cigar in our rooms,
+Colonel, I shall be happy to give you any other details which
+might interest you.”

--- a/silkie.py
+++ b/silkie.py
@@ -10,6 +10,7 @@ from yattag import Doc, indent
 
 SUPORTED_FILE_EXTENSION = ".txt"
 SUPORTED_FILE_EXTENSION2 = ".md"
+
 DIST_DIRECTORY_PATH = path.join(
     path.dirname(path.realpath(__file__)), "dist")
 
@@ -42,27 +43,30 @@ def silkie(input, stylesheet):
         # Generate static file(s)
         # TODO: need to refactor the code to be shorter but should be fine for now
         if path.isfile(input):
-            if stylesheet:
-                generate_static_file(SUPORTED_FILE_EXTENSION, stylesheet)
-            else:
-                generate_static_file(input, SUPORTED_FILE_EXTENSION)
-        if path.isfile(input):
-            if stylesheet:
-                generate_static_file(SUPORTED_FILE_EXTENSION2, stylesheet)
-            else:
-                generate_static_file(input, SUPORTED_FILE_EXTENSION2)
+            print(pathlib.Path(input).suffix)
+            if pathlib.Path(input).suffix == '.txt':
+                if stylesheet:
+                    generate_static_file(SUPORTED_FILE_EXTENSION, stylesheet)
+                else:
+                    generate_static_file(input, SUPORTED_FILE_EXTENSION)
+            elif pathlib.Path(input).suffix == '.md':    
+                if stylesheet:
+                    generate_static_file(SUPORTED_FILE_EXTENSION, stylesheet)
+                else:
+                    generate_static_file(input, SUPORTED_FILE_EXTENSION2)
+                
         if path.isdir(input):
-           for filepath in glob.glob(path.join(input, "*" + SUPORTED_FILE_EXTENSION)):
+            for filepath in glob.glob(path.join(input, "*" + SUPORTED_FILE_EXTENSION)):
                 if stylesheet:
                     generate_static_file(filepath, SUPORTED_FILE_EXTENSION, stylesheet)
                 else:
                     generate_static_file(filepath, SUPORTED_FILE_EXTENSION)
-        if path.isdir(input):
             for filepath in glob.glob(path.join(input, "*" + SUPORTED_FILE_EXTENSION2)):
                 if stylesheet:
                     generate_static_file(filepath, SUPORTED_FILE_EXTENSION2, stylesheet)
                 else:
                     generate_static_file(filepath, SUPORTED_FILE_EXTENSION2)
+                    
     except OSError as e:
         click.echo(
             f"{TextColor.FAIL}\u2715 Error: Build directory can't be created!{TextColor.ENDC}")

--- a/silkie.py
+++ b/silkie.py
@@ -84,7 +84,12 @@ def get_filename(file_path: str) -> str:
     """Extract the name of the file without (all) its extension(s)"""
     # ISSUE
     # add a note to your potential issue with code here for empty name files
-    return pathlib.Path(file_path.split('.')[1]).stem
+    if pathlib.Path(file_path.split('.')[0]).stem == ".md" or pathlib.Path(file_path.split('.')[0]).stem == ".txt":
+        return pathlib.Path(file_path.split('.')[0]).stem
+    elif pathlib.Path(file_path.split('.')[1]).stem == ".md" or pathlib.Path(file_path.split('.')[1]).stem == ".md":
+        return pathlib.Path(file_path.split('.')[1]).stem
+    else:
+        return pathlib.Path(file_path.split('.')[0]).stem
     """ 
     linux distribution - works
     Windows 11 -seems to be only a windows 11 issue with above line being pathlib.Path(file_path.split('.')[1]).stem to work"""
@@ -170,10 +175,8 @@ def get_html_paragraphs_parsewithmd(line, tag, file_path: str) -> None:
 
 def get_html(file_path: str, stylesheet_url: str, extension: str) -> str:
     """Return an indented HTML document with the content of the file"""
-    print(extension)
     doc, tag, text, line = Doc().ttl()
     title = get_title(file_path)
-
     doc.asis('<!DOCTYPE html>')
     with tag('html'):
         doc.attr(lang='en')


### PR DESCRIPTION
an issue always came up when running that relates to line 87 in skilie.py
``` return pathlib.Path(file_path.split('.')[X]).stem ```
where X should be a 0 or 1 depending on the parsing

further investigation is needed as a separate potential bug
